### PR TITLE
Fix load_vad_model order and parameters for WhisperX v3.4.2

### DIFF
--- a/generateSubtitles.py
+++ b/generateSubtitles.py
@@ -224,11 +224,11 @@ def main() -> None:
     logging.info("Using device: %s", device)
 
     model = whisperx.load_model(args.model_size, device, compute_type=compute_type)
-    # ``load_vad_model`` initializes the pyannote VAD pipeline with optional thresholds.
+    # ``load_vad_model`` initializes the pyannote VAD pipeline with optional onset/offset parameters.
     vad_model = load_vad_model(
+        device,
         args.vad_model,
-        vad_options={"vad_onset": args.vad_onset, "vad_offset": args.vad_offset},
-        device=device,
+        vad_options={"onset": args.vad_onset, "offset": args.vad_offset},
     )
 
     options: Dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- Call `load_vad_model` with device as first argument
- Pass Pyannote VAD onset/offset parameters

## Testing
- `python -m py_compile generateSubtitles.py`
- `python generateSubtitles.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6891d8f977c08333849974dad407a157