### PR TITLE
Default to audio track 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ corresponding videos.
 The CLI exposes a number of switches for customising behaviour:
 
 - `--extensions`: video file extensions to search for (default: `.mp4 .mkv .mov .avi`)
-- `--audio-track`: select which audio track to extract (default: `0`)
+- `--audio-track`: select which audio track to extract (default: `1`; use `0` for first track)
 - `--model-size`: Whisper model size to load
 - `--vad-model`: VAD backend (`silero_vad` by default)
 - `--vad-threshold`: activation threshold for VAD (default: `0.35`)

--- a/generateSubtitles.py
+++ b/generateSubtitles.py
@@ -173,8 +173,8 @@ def main() -> None:
     parser.add_argument(
         "--audio-track",
         type=int,
-        default=0,
-        help="Audio track index to extract (default: 0)",
+        default=1,
+        help="Audio track index to extract (default: 1; use 0 for first track)",
     )
     parser.add_argument("--model-size", default="medium", help="Whisper model size")
     parser.add_argument(


### PR DESCRIPTION
## Summary
- default `--audio-track` to 1 instead of 0
- clarify help text and README to explain 0-based track indexing

## Testing
- `PYTHONPATH=/tmp/stubs python generateSubtitles.py --help | head -n 40`
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_6891d9d3b3c4833381286d7b5dad8839