### PR TITLE
feat: allow specifying language

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Sample command with explicit options:
 python generateSubtitles.py ./media \
     --model-size medium \
     --output-format vtt \
-    --extensions .mp4 .mkv
+    --extensions .mp4 .mkv \
+    --language en
 ```
 
 Subtitle files (`.srt` or `.vtt`) will be written alongside the
@@ -67,7 +68,7 @@ The CLI exposes a number of switches for customising behaviour:
 - `--output-format`: subtitle format (`srt` or `vtt`, default `srt`)
 - `--max-line-width`: maximum characters per subtitle line (default: `42`)
 - `--max-lines`: maximum lines per subtitle (default: `2`)
-- `--language`: override language detection with a code like `en`
+- `--language`: override language detection with a code like `en` (default: auto)
 
 ## Potential Enhancements
 

--- a/generateSubtitles.py
+++ b/generateSubtitles.py
@@ -232,7 +232,12 @@ def _init_worker(args: Dict[str, Any], options: Dict[str, Any]) -> None:
     OPTIONS = options
     DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     compute_type = "float16" if DEVICE.type == "cuda" else "int8"
-    MODEL = whisperx.load_model(ARGS["model_size"], DEVICE, compute_type=compute_type)
+    MODEL = whisperx.load_model(
+        ARGS["model_size"],
+        DEVICE,
+        compute_type=compute_type,
+        language=ARGS.get("language"),
+    )
     VAD_MODEL = load_vad_model(
         DEVICE,
         ARGS["vad_model"],
@@ -328,7 +333,7 @@ def main() -> None:
     parser.add_argument(
         "--language",
         default=None,
-        help="Override language detection (e.g. 'en')",
+        help="Language for transcription (e.g. 'en'); default: auto-detect",
     )
     parser.add_argument(
         "--word-timestamps",
@@ -349,9 +354,7 @@ def main() -> None:
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
 
-    options: Dict[str, Any] = {}
-    if args.language:
-        options["language"] = args.language
+    options: Dict[str, Any] = {"language": args.language}
     if args.word_timestamps:
         options["word_timestamps"] = True
 


### PR DESCRIPTION
## Summary
- allow setting a preferred language for model loading and transcription
- document `--language` usage and example

## Testing
- `python -m py_compile generateSubtitles.py`
- `pip install whisperx` *(fails: Could not find a version that satisfies the requirement whisperx)*
- `pip install torch` *(fails: Could not find a version that satisfies the requirement torch)*
- `python generateSubtitles.py --help` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6891e04a09f08333a91205ba98c51d59