### PR TITLE
Add logging for each subtitle processing run

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ python generateSubtitles.py ./media \
 Subtitle files (`.srt` or `.vtt`) will be written alongside the
 corresponding videos.
 
+## Logging
+
+After each video is processed a summary entry is appended to
+`logs/subtitle_run.json`. The record includes start and end timestamps,
+whether the operation succeeded, and any associated error message. The
+`logs` directory is created automatically if it does not already exist.
+
 ## Configurable Options
 
 The CLI exposes a number of switches for customising behaviour:


### PR DESCRIPTION
## Summary
- log start/end time, success flag, and errors for every processed video to `logs/subtitle_run.json`
- ensure `logs` directory exists
- document the new logging behaviour in the README

## Testing
- `python -m py_compile generateSubtitles.py`
- `python generateSubtitles.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6891e394c9e08333957c50ad8ee27d7c