### PR TITLE
feat: add output directory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,14 @@ Sample command with explicit options:
 python generateSubtitles.py ./media \
     --model-size medium \
     --output-format vtt \
+    --output-dir ./subs \
     --extensions .mp4 .mkv \
     --language en
 ```
 
 Subtitle files (`.srt` or `.vtt`) will be written alongside the
-corresponding videos.
+corresponding videos by default.  Use `--output-dir` to place them under a
+separate directory while preserving the videos' relative paths.
 
 ## Logging
 
@@ -73,6 +75,8 @@ The CLI exposes a number of switches for customising behaviour:
 - `--vad-model`: VAD backend (`silero_vad` by default)
 - `--vad-threshold`: activation threshold for VAD (default: `0.35`)
 - `--output-format`: subtitle format (`srt` or `vtt`, default `srt`)
+- `--output-dir`: directory where subtitle files are written; relative paths
+  under the input directory are preserved
 - `--max-line-width`: maximum characters per subtitle line (default: `42`)
 - `--max-lines`: maximum lines per subtitle (default: `2`)
 - `--language`: override language detection with a code like `en` (default: auto)

--- a/generateSubtitles.py
+++ b/generateSubtitles.py
@@ -269,9 +269,16 @@ def process_video(video: Path) -> Dict[str, Any]:
                 OPTIONS,
                 DIARIZE_MODEL,
             )
+            output_path = video
+            if ARGS.get("output_dir"):
+                root_dir = Path(ARGS["directory"])
+                rel_path = video.relative_to(root_dir)
+                output_path = Path(ARGS["output_dir"]) / rel_path
+            output_path = output_path.with_suffix("." + ARGS["output_format"])
+            output_path.parent.mkdir(parents=True, exist_ok=True)
             write_subtitles(
                 segments,
-                video.with_suffix("." + ARGS["output_format"]),
+                output_path,
                 fmt=ARGS["output_format"],
                 max_line_width=ARGS["max_line_width"],
                 max_lines=ARGS["max_lines"],
@@ -333,6 +340,11 @@ def main() -> None:
         help="Subtitle output format",
     )
     parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Directory to write subtitle files to; relative paths are preserved",
+    )
+    parser.add_argument(
         "--max-line-width",
         type=int,
         default=42,
@@ -368,6 +380,10 @@ def main() -> None:
     options: Dict[str, Any] = {"language": args.language}
     if args.word_timestamps:
         options["word_timestamps"] = True
+
+    if args.output_dir:
+        args.output_dir = str(Path(args.output_dir))
+        Path(args.output_dir).mkdir(parents=True, exist_ok=True)
 
     videos = discover_videos(Path(args.directory), args.extensions)
     if not videos:


### PR DESCRIPTION
## Summary
- allow subtitles to be saved under a dedicated directory via `--output-dir`
- support directory creation and relative path mirroring
- document new `--output-dir` usage and options

## Testing
- `python -m py_compile generateSubtitles.py`
- `python generateSubtitles.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6891e5340dd4833383c999bb5dbee6f3