### PR TITLE
feat: add text normalization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ The CLI exposes a number of switches for customising behaviour:
   under the input directory are preserved
 - `--max-line-width`: maximum characters per subtitle line (default: `42`)
 - `--max-lines`: maximum lines per subtitle (default: `2`)
+- `--case`: normalise subtitle text casing (`lower` or `upper`)
+- `--strip-punctuation`: remove punctuation from subtitle text
 - `--language`: override language detection with a code like `en` (default: auto)
 
 ## Potential Enhancements


### PR DESCRIPTION
## Summary
- normalize whitespace, optional casing and punctuation when writing subtitles
- expose `--case` and `--strip-punctuation` CLI flags alongside line wrapping controls
- document text normalization options in the README

## Testing
- `python -m py_compile generateSubtitles.py`
- `python generateSubtitles.py --help` *(fails: No module named 'torch')*
- `pip install torch --quiet` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_6891e648486c8333be58967b721bb36d