### PR TITLE
Add mocked unit tests for subtitle utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,15 @@ The CLI exposes a number of switches for customising behaviour:
   activated before running the script.
 - Review `failed_subtitles.log` for videos that could not be processed.
 
+## Running Tests
+
+The project includes a small pytest suite with mocked dependencies. To run
+the tests, execute:
+
+```bash
+pytest
+```
+
+The tests use mock objects so they do not require heavy dependencies such as
+`ffmpeg` or `whisperx` to be installed.
+

--- a/tests/test_generate_subtitles.py
+++ b/tests/test_generate_subtitles.py
@@ -1,0 +1,87 @@
+import importlib
+import types
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def gs(monkeypatch):
+    """Provide the generateSubtitles module with stubbed heavy deps."""
+    import shutil
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+    # Stub external modules before importing generateSubtitles
+    dummy_torch = types.ModuleType("torch")
+    dummy_torch.device = lambda *a, **k: "cpu"
+    dummy_torch.cuda = types.SimpleNamespace(is_available=lambda: False, empty_cache=lambda: None)
+    sys.modules.setdefault("torch", dummy_torch)
+
+    dummy_whisperx = types.ModuleType("whisperx")
+    dummy_whisperx.load_audio = lambda path: [0.0] * 16000
+    dummy_whisperx.audio = types.SimpleNamespace(SAMPLE_RATE=16000)
+    sys.modules.setdefault("whisperx", dummy_whisperx)
+    sys.modules.setdefault("whisperx.audio", dummy_whisperx.audio)
+    dummy_vads_pyannote = types.ModuleType("whisperx.vads.pyannote")
+    dummy_vads_pyannote.load_vad_model = lambda *a, **k: None
+    sys.modules.setdefault("whisperx.vads", types.ModuleType("whisperx.vads"))
+    sys.modules.setdefault("whisperx.vads.pyannote", dummy_vads_pyannote)
+    sys.modules.setdefault("pyannote", types.ModuleType("pyannote"))
+    sys.modules.setdefault("pyannote.audio", types.ModuleType("pyannote.audio"))
+
+    monkeypatch.setattr(shutil, "which", lambda cmd: f"/usr/bin/{cmd}")
+
+    module = importlib.import_module("generateSubtitles")
+    return module
+
+
+def test_extract_audio(gs, tmp_path, monkeypatch):
+    video = tmp_path / "clip.mp4"
+    called = {}
+
+    def fake_run(cmd, check, stdout, stderr):
+        called["cmd"] = cmd
+        return types.SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(gs.subprocess, "run", fake_run)
+    result = gs.extract_audio(video, 0, tmp_path)
+    assert result == tmp_path / "clip.wav"
+    assert called["cmd"][0] == "ffmpeg"
+    assert f"0:a:0" in called["cmd"]
+
+
+def test_transcribe_file(gs, monkeypatch):
+    audio_path = Path("dummy.wav")
+    dummy_audio = [0.0] * 8000
+    monkeypatch.setattr(gs.whisperx, "load_audio", lambda p: dummy_audio)
+
+    class FakeModel:
+        def __init__(self):
+            self.last_segments = None
+
+        def transcribe(self, audio, segments=None, **options):
+            self.last_segments = segments
+            return {"segments": [{"start": 0.0, "end": 1.0, "text": "hi"}]}
+
+    def fake_vad(audio):
+        return [{"start": 0.0, "end": 1.0}]
+
+    def fake_diar(audio, segments):
+        return [{"start": 0.0, "end": 1.0, "speaker": "S1"}]
+
+    model = FakeModel()
+    segments = gs.transcribe_file(audio_path, model, fake_vad, gs.torch.device("cpu"), {}, fake_diar)
+    assert model.last_segments == [{"start": 0.0, "end": 1.0}]
+    assert segments[0]["speaker"] == "S1"
+
+
+def test_write_subtitles(gs, tmp_path):
+    segments = [{"start": 0.0, "end": 1.0, "text": "Hello, WORLD!"}]
+    out = tmp_path / "out"
+    result = gs.write_subtitles(segments, out, fmt="srt", case="lower", strip_punctuation=True)
+    text = result.read_text(encoding="utf-8")
+    assert "00:00:00,000 --> 00:00:01,000" in text
+    assert "hello world" in text


### PR DESCRIPTION
## Summary
- add pytest tests for extract_audio, transcribe_file, and write_subtitles
- mock heavy dependencies and external calls to isolate unit logic
- document how to run the test suite in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689201f1b40c8333b176ed686ad835aa