### PR TITLE
Validate model size names and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ preserving each video's relative path.
 ### Tuning VAD thresholds and model size
 
 ```bash
-python generateSubtitles.py ./videos --vad-onset 0.6 --vad-offset 0.4 --model-size large
+python generateSubtitles.py ./videos --vad-onset 0.6 --vad-offset 0.4 --model-size large-v2
 ```
 
 Adjust the VAD sensitivity and use a larger Whisper model for potentially
@@ -163,7 +163,7 @@ The CLI exposes a number of switches for customising behaviour:
 - `--extensions`: video file extensions to search for (default: `.mp4 .mkv .mov .avi`)
 - `--audio-track`: select which audio track to extract (default: `1`; use `0` for first track). Run `--list-audio-tracks` to discover track indices
 - `--list-audio-tracks VIDEO`: list audio tracks for a single video and exit
-- `--model-size`: Whisper model size to load
+- `--model-size`: Whisper model size to load (e.g., `base`, `large-v2`; default: `large-v2`)
 - `--vad-model`: VAD backend (`pyannote/segmentation` by default)
 - `--vad-onset`: onset probability threshold for VAD (default: `0.5`)
 - `--vad-offset`: offset probability threshold for VAD (default: `0.363`)

--- a/generateSubtitles.py
+++ b/generateSubtitles.py
@@ -453,7 +453,11 @@ def main() -> None:
         default=1,
         help="Audio track index to extract (default: 1; use 0 for first track)",
     )
-    parser.add_argument("--model-size", default="large_v2", help="Whisper model size")
+    parser.add_argument(
+        "--model-size",
+        default="large-v2",
+        help="Whisper model size (e.g., 'base', 'large-v2')",
+    )
     parser.add_argument(
         "--vad-model",
         default="pyannote/segmentation",
@@ -524,6 +528,31 @@ def main() -> None:
         help="Number of parallel worker processes",
     )
     args = parser.parse_args()
+    valid_models = {
+        "tiny.en",
+        "tiny",
+        "base.en",
+        "base",
+        "small.en",
+        "small",
+        "medium.en",
+        "medium",
+        "large-v1",
+        "large-v2",
+        "large-v3",
+        "large",
+        "distil-large-v2",
+        "distil-medium.en",
+        "distil-small.en",
+        "distil-large-v3",
+        "large-v3-turbo",
+        "turbo",
+    }
+    if args.model_size not in valid_models:
+        parser.error(
+            f"Invalid model size '{args.model_size}'. Choose from: {', '.join(sorted(valid_models))}"
+        )
+
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
 
     if args.list_audio_tracks:


### PR DESCRIPTION
## Summary
- default to `large-v2` for `--model-size`
- validate `--model-size` against supported model names
- document hyphenated model sizes in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892178a703083339930a5347941273c