### PR TITLE
Pin ctranslate2 and silence pkg_resources deprecation

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   # Uncomment the following line to match your CUDA toolkit version
   # - pytorch-cuda=11.8  # requires NVIDIA channel
   - pip:
+      - ctranslate2>=4.3  # use version without pkg_resources
       - torch            # install the build matching your CUDA version
       - pyannote.audio
       - whisperx

--- a/generateSubtitles.py
+++ b/generateSubtitles.py
@@ -21,10 +21,14 @@ import tempfile
 import textwrap
 import shutil
 import sys
+import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable, List, Dict, Any
 
+
+warnings.filterwarnings("ignore", message="pkg_resources is deprecated")
+# TODO: Remove once dependencies (e.g., ctranslate2) drop pkg_resources
 
 def _check_dependencies() -> None:
     """Ensure required third-party libraries and executables are available.


### PR DESCRIPTION
## Summary
- Require a recent ctranslate2 release that no longer relies on pkg_resources
- Suppress pkg_resources deprecation warnings until dependencies are updated

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68921adc620083338e75f6ab566da2bf