### PR TITLE
Ensure whisperx uses device type string

### DIFF
--- a/generateSubtitles.py
+++ b/generateSubtitles.py
@@ -364,10 +364,11 @@ def _init_worker(args: Dict[str, Any], options: Dict[str, Any]) -> None:
     ARGS = args
     OPTIONS = options
     DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    compute_type = "float16" if DEVICE.type == "cuda" else "int8"
+    compute_type = "float16" if getattr(DEVICE, "type", DEVICE) == "cuda" else "int8"
+    device_str = DEVICE.type if hasattr(DEVICE, "type") else str(DEVICE)
     MODEL = whisperx.load_model(
         ARGS["model_size"],
-        DEVICE,
+        device_str,
         compute_type=compute_type,
         language=ARGS.get("language"),
     )


### PR DESCRIPTION
## Summary
- Pass the device type string to `whisperx.load_model` during worker initialization
- Determine compute type using the resolved device type

## Testing
- `pytest -q`
- `python - <<'PY'
import types, sys, shutil
class D:
    def __init__(self,t): self.type=t
sys.modules['torch']=types.SimpleNamespace(device=lambda *a,**k:D('cpu'), cuda=types.SimpleNamespace(is_available=lambda:False, empty_cache=lambda:None))
sys.modules['whisperx']=types.SimpleNamespace(load_model=lambda *a,**k:print('CPU', a[1]))
sys.modules['whisperx.audio']=types.SimpleNamespace(SAMPLE_RATE=16000)
sys.modules['whisperx.vads']=types.ModuleType('whisperx.vads')
sys.modules['whisperx.vads.pyannote']=types.SimpleNamespace(load_vad_model=lambda *a,**k:None)
sys.modules['pyannote']=types.ModuleType('pyannote')
sys.modules['pyannote.audio']=types.ModuleType('pyannote.audio')
shutil.which=lambda cmd:'/usr/bin/'+cmd
import generateSubtitles as gs
gs._init_worker({'model_size':'tiny','language':'en','vad_model':'stub','vad_onset':0.5,'vad_offset':0.5}, {})
PY`
- `python - <<'PY'
import types, sys, shutil
class D:
    def __init__(self,t): self.type=t
sys.modules['torch']=types.SimpleNamespace(device=lambda *a,**k:D('cuda'), cuda=types.SimpleNamespace(is_available=lambda:True, empty_cache=lambda:None))
sys.modules['whisperx']=types.SimpleNamespace(load_model=lambda *a,**k:print('CUDA', a[1]))
sys.modules['whisperx.audio']=types.SimpleNamespace(SAMPLE_RATE=16000)
sys.modules['whisperx.vads']=types.ModuleType('whisperx.vads')
sys.modules['whisperx.vads.pyannote']=types.SimpleNamespace(load_vad_model=lambda *a,**k:None)
sys.modules['pyannote']=types.ModuleType('pyannote')
sys.modules['pyannote.audio']=types.ModuleType('pyannote.audio')
shutil.which=lambda cmd:'/usr/bin/'+cmd
import generateSubtitles as gs
gs._init_worker({'model_size':'tiny','language':'en','vad_model':'stub','vad_onset':0.5,'vad_offset':0.5}, {})
PY`
- `pip install torch whisperx` (fails: `ProxyError: Cannot connect to proxy, Tunnel connection failed: 403 Forbidden`)


------
https://chatgpt.com/codex/tasks/task_e_68921f2f62288333a6c8bec7c0d4d2f8