### PR TITLE
Fix VAD init to use device type

### DIFF
--- a/generateSubtitles.py
+++ b/generateSubtitles.py
@@ -373,7 +373,7 @@ def _init_worker(args: Dict[str, Any], options: Dict[str, Any]) -> None:
         language=ARGS.get("language"),
     )
     VAD_MODEL = load_vad_model(
-        DEVICE,
+        getattr(DEVICE, "type", DEVICE),
         ARGS["vad_model"],
         vad_options={"onset": ARGS["vad_onset"], "offset": ARGS["vad_offset"]},
     )


### PR DESCRIPTION
## Summary
- pass device type string into `load_vad_model` to support CPU/GPU execution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68922089505c8333871f3e05eef1e212