### PR TITLE
Pass onset and offset to VAD

### DIFF
--- a/generateSubtitles.py
+++ b/generateSubtitles.py
@@ -181,7 +181,11 @@ def transcribe_file(
     if vad_model is not None:
         logging.debug("Running VAD to obtain speech segments")
         try:
-            speech_segments = vad_model(audio)
+            speech_segments = vad_model(
+                audio,
+                onset=ARGS["vad_onset"],
+                offset=ARGS["vad_offset"],
+            )
             if not speech_segments:
                 logging.warning("VAD produced no segments; falling back to chunking")
                 speech_segments = None


### PR DESCRIPTION
## Summary
- forward user-configurable onset/offset values to the WhisperX VAD
- verify VAD options are used during transcription

## Testing
- `pytest -q`
- attempt to install runtime dependencies for real VAD execution (failed: no network access)


------
https://chatgpt.com/codex/tasks/task_e_689226171118833399e7366e3c542e8c