### PR TITLE
Use neutral directory default

### DIFF
--- a/generateSubtitles.py
+++ b/generateSubtitles.py
@@ -442,7 +442,7 @@ def main() -> None:
     parser.add_argument(
         "directory",
         nargs="?",
-        default="E:\Movies Series\One Pace - One Piece\[One Pace][101-105] Reverse Mountain [1080p]",
+        default=".",
         help="Directory to recursively scan for videos",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- Replace hard-coded directory default with a neutral '.' path to avoid escape sequence issues

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68924a9193988333aa6fb729fc90634d