### PR TITLE
Pass waveform dict to VAD

### DIFF
--- a/generateSubtitles.py
+++ b/generateSubtitles.py
@@ -181,8 +181,10 @@ def transcribe_file(
     if vad_model is not None:
         logging.debug("Running VAD to obtain speech segments")
         try:
+            import torch
+
             speech_segments = vad_model(
-                audio,
+                {"waveform": torch.tensor(audio), "sample_rate": SAMPLE_RATE},
                 onset=ARGS["vad_onset"],
                 offset=ARGS["vad_offset"],
             )

--- a/tests/test_generate_subtitles.py
+++ b/tests/test_generate_subtitles.py
@@ -18,6 +18,7 @@ def gs(monkeypatch):
     dummy_torch = types.ModuleType("torch")
     dummy_torch.device = lambda *a, **k: "cpu"
     dummy_torch.cuda = types.SimpleNamespace(is_available=lambda: False, empty_cache=lambda: None)
+    dummy_torch.tensor = lambda x: x
     sys.modules.setdefault("torch", dummy_torch)
 
     dummy_whisperx = types.ModuleType("whisperx")


### PR DESCRIPTION
## Summary
- pass waveform tensors to the VAD model to match its expected input
- extend tests to stub torch.tensor in the fake torch module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68924b7fee088333a5ac691d395c3e7f