### PR TITLE
Pin speechbrain for pyannote compatibility

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
       - ctranslate2>=4.3  # use version without pkg_resources
       - torch==1.10.*    # pin for compatibility with legacy pyannote models
       - pyannote.audio==0.0.1
+      - speechbrain==0.5.16  # pin for compatibility with pyannote.audio
       - whisperx
       # Optional extras
       - rich             # pretty logging in the terminal


### PR DESCRIPTION
## Summary
- pin speechbrain to 0.5.16 to satisfy pyannote.audio compatibility requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68924f1adc0083339e827721a7116010