### PR TITLE
Use torch.from_numpy for VAD waveform input

### DIFF
--- a/generateSubtitles.py
+++ b/generateSubtitles.py
@@ -78,6 +78,7 @@ def _check_dependencies() -> None:
 _check_dependencies()
 
 import torch
+import numpy as np
 import whisperx
 from whisperx.vads.pyannote import load_vad_model
 from whisperx.audio import SAMPLE_RATE
@@ -205,7 +206,7 @@ def transcribe_file(
     """
     options = options or {}
     logging.debug("Loading audio for transcription: %s", audio_path)
-    audio = whisperx.load_audio(audio_path)
+    audio = np.asarray(whisperx.load_audio(audio_path))
 
     speech_segments = None
     if vad_model is not None:
@@ -214,7 +215,10 @@ def transcribe_file(
             import torch
 
             speech_segments = vad_model(
-                {"waveform": torch.tensor(audio), "sample_rate": SAMPLE_RATE},
+                {
+                    "waveform": torch.from_numpy(audio).unsqueeze(0),
+                    "sample_rate": SAMPLE_RATE,
+                },
                 onset=ARGS["vad_onset"],
                 offset=ARGS["vad_offset"],
             )

--- a/tests/test_generate_subtitles.py
+++ b/tests/test_generate_subtitles.py
@@ -19,6 +19,7 @@ def gs(monkeypatch):
     dummy_torch.device = lambda *a, **k: "cpu"
     dummy_torch.cuda = types.SimpleNamespace(is_available=lambda: False, empty_cache=lambda: None)
     dummy_torch.tensor = lambda x: x
+    dummy_torch.from_numpy = lambda arr: types.SimpleNamespace(unsqueeze=lambda dim: arr)
     sys.modules.setdefault("torch", dummy_torch)
 
     dummy_whisperx = types.ModuleType("whisperx")


### PR DESCRIPTION
## Summary
- Ensure audio loaded by `transcribe_file` is converted to a NumPy array
- Pass VAD waveform using `torch.from_numpy(...).unsqueeze(0)`
- Adjust tests to stub `torch.from_numpy`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892d8bcb5888333baefe729dbbab1bd