### PR TITLE
Handle empty transcription segments

### DIFF
--- a/generateSubtitles.py
+++ b/generateSubtitles.py
@@ -440,6 +440,11 @@ def process_video(video: Path) -> Dict[str, Any]:
                 OPTIONS,
                 DIARIZE_MODEL,
             )
+            if not segments:
+                logging.warning("No subtitle segments were produced for %s", video)
+                with open("failed_subtitles.log", "a", encoding="utf-8") as failed:
+                    failed.write(f"{video}: no segments\n")
+                raise ValueError("Transcription produced no segments")
             output_path = video
             if ARGS.get("output_dir"):
                 root_dir = Path(ARGS["directory"])


### PR DESCRIPTION
## Summary
- warn and abort subtitle creation when transcription returns no segments
- log videos with no transcription segments to `failed_subtitles.log`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892e69254b48333b180292c55f12983