### PR TITLE
refactor: remove globals and add worker factory

### DIFF
--- a/tests/test_generate_subtitles.py
+++ b/tests/test_generate_subtitles.py
@@ -113,21 +113,18 @@ def test_transcribe_file(gs, monkeypatch):
 
         return diar_fn
 
-    gs.ARGS["vad_onset"] = 0.3
-    gs.ARGS["vad_offset"] = 0.5
-    gs.ARGS["diarize"] = True
-    gs.DIARIZE_MODEL = None
-
     monkeypatch.setattr(gs.whisperx, "load_align_model", fake_load_align_model)
     monkeypatch.setattr(gs.whisperx, "align", fake_align)
     monkeypatch.setattr(gs.whisperx.diarize, "load_diarize_model", fake_load_diarize_model)
 
     model = FakeModel()
-    segments = gs.transcribe_file(
+    args = {"vad_onset": 0.3, "vad_offset": 0.5, "diarize": True}
+    segments, _ = gs.transcribe_file(
         audio_path,
         model,
         None,
         gs.torch.device("cpu"),
+        args,
         {},
     )
     assert model.last_kwargs["vad_filter"] is True


### PR DESCRIPTION
## Summary
- load heavy models within worker function instead of globals
- pass configuration explicitly to avoid shared mutable state
- process videos sequentially to reduce GPU memory contention

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893040ba0008333b307b01c3117435b