### PR TITLE
Use options dict for transcription

### DIFF
--- a/generateSubtitles.py
+++ b/generateSubtitles.py
@@ -213,12 +213,7 @@ def transcribe_file(
     audio = np.asarray(whisperx.load_audio(audio_path))
 
     logging.info("Transcribing %s", audio_path)
-    result = model.transcribe(
-        audio,
-        vad_filter=True,
-        vad_parameters={"onset": args["vad_onset"], "offset": args["vad_offset"]},
-        **options,
-    )
+    result = model.transcribe(audio, **options)
     segments: List[Dict[str, Any]] = result.get("segments", [])
 
     # Align segments to the audio for more accurate timestamps

--- a/tests/test_generate_subtitles.py
+++ b/tests/test_generate_subtitles.py
@@ -129,14 +129,15 @@ def test_transcribe_file(gs, monkeypatch):
     monkeypatch.setattr(gs.whisperx.diarize, "load_diarize_model", fake_load_diarize_model)
 
     model = FakeModel()
-    args = {"vad_onset": 0.3, "vad_offset": 0.5, "diarize": True}
+    args = {"diarize": True}
+    options = {"vad_filter": True, "vad_parameters": {"onset": 0.3, "offset": 0.5}}
     segments, _ = gs.transcribe_file(
         audio_path,
         model,
         None,
         gs.torch.device("cpu"),
         args,
-        {},
+        options,
     )
     assert model.last_kwargs["vad_filter"] is True
     assert model.last_kwargs["vad_parameters"] == {"onset": 0.3, "offset": 0.5}


### PR DESCRIPTION
## Summary
- Route VAD settings through options dictionary and simplify `transcribe_file`
- Update unit tests to supply `vad_filter` and `vad_parameters`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68931a249df08333876dd91ba45d2f5c