### PR TITLE
Simplify pipeline by removing explicit VAD model handling

### DIFF
--- a/tests/test_generate_subtitles.py
+++ b/tests/test_generate_subtitles.py
@@ -42,11 +42,6 @@ def gs(monkeypatch):
     dummy_numpy.asarray = lambda x: x
     sys.modules.setdefault("numpy", dummy_numpy)
 
-    dummy_vads_pyannote = types.ModuleType("whisperx.vads.pyannote")
-    dummy_vads_pyannote.load_vad_model = lambda *a, **k: None
-    sys.modules["whisperx.vads"] = types.ModuleType("whisperx.vads")
-    sys.modules["whisperx.vads.pyannote"] = dummy_vads_pyannote
-
     dummy_pyannote = types.ModuleType("pyannote")
     dummy_pyannote.__path__ = []
     dummy_pyannote_audio = types.ModuleType("pyannote.audio")
@@ -134,7 +129,6 @@ def test_transcribe_file(gs, monkeypatch):
     segments, _ = gs.transcribe_file(
         audio_path,
         model,
-        None,
         gs.torch.device("cpu"),
         args,
         options,


### PR DESCRIPTION
## Summary
- drop `load_vad_model` usage and `vad_model` parameter across transcription pipeline
- streamline CLI and worker setup to rely on default VAD behavior
- adjust tests for new `transcribe_file` signature

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68931b0f48948333af0bf0ca3a250c80