### PR TITLE
Make language argument optional

### DIFF
--- a/generateSubtitles.py
+++ b/generateSubtitles.py
@@ -536,8 +536,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--language",
-        default='en',
-        help="Language for transcription (e.g. 'en'); default: auto-detect",
+        default=None,
+        help="Language for transcription (e.g. 'en'); leave unset for auto-detect",
     )
     parser.add_argument(
         "--word-timestamps",
@@ -583,9 +583,9 @@ def main() -> None:
     if not args.directory:
         parser.error("directory is required unless --list-audio-tracks is used")
 
-    options: Dict[str, Any] = {
-        "language": args.language,
-    }
+    options: Dict[str, Any] = {}
+    if args.language:
+        options["language"] = args.language
     if args.word_timestamps:
         options["word_timestamps"] = True
 


### PR DESCRIPTION
## Summary
- Allow WhisperX to auto-detect transcription language by default
- Only include `language` option when user explicitly requests it

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68934699572c8333a74e72bdac66cdc4