### PR TITLE
Expose VAD options for WhisperX transcription

### DIFF
--- a/tests/test_generate_subtitles.py
+++ b/tests/test_generate_subtitles.py
@@ -147,8 +147,18 @@ def test_transcribe_file(gs, monkeypatch):
     monkeypatch.setattr(gs.whisperx.diarize, "load_diarize_model", fake_load_diarize_model)
 
     model = FakeModel()
-    args = {"diarize": True}
-    options = {"language": "en"}
+    args = {
+        "diarize": True,
+        "vad_filter": False,
+        "vad_onset": 0.5,
+        "vad_offset": 0.5,
+    }
+    options = {
+        "language": "en",
+        "vad_filter": False,
+        "vad_onset": 0.5,
+        "vad_offset": 0.5,
+    }
     segments, _ = gs.transcribe_file(
         audio_path,
         model,
@@ -156,7 +166,12 @@ def test_transcribe_file(gs, monkeypatch):
         args,
         options,
     )
-    assert model.last_kwargs == {"language": "en"}
+    assert model.last_kwargs == {
+        "language": "en",
+        "vad_filter": False,
+        "vad_onset": 0.5,
+        "vad_offset": 0.5,
+    }
     assert segments[0]["text"] == "aligned"
     assert segments[0]["speaker"] == "S1"
     assert calls["load_align_model"][1] == gs.torch.device("cpu")


### PR DESCRIPTION
## Summary
- add `--vad-filter`, `--vad-onset`, and `--vad-offset` flags to the CLI
- pass VAD configuration into transcription call
- update tests for new VAD behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893569e3c1c8333b6143a02bd0c5145