### PR TITLE
Add music segment detection utility

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
       - pyannote.audio>=3.3
       - speechbrain>=1.0
       - whisperx>=3.4.2,<4
+      - librosa>=0.10
       - packaging        # version parsing for dependency checks
       # Optional extras
       - rich             # pretty logging in the terminal


### PR DESCRIPTION
## Summary
- add `detect_music_segments` to locate percussive-heavy regions and emit `music_segments.json`
- expose new `music` CLI subcommand in `preproc.py`
- add `librosa` dependency to environment

## Testing
- `pip install librosa`
- `pip install noisereduce`
- `python preproc.py --help`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68944df26d4883338670dfee9c595441