### PR TITLE
Add denoise aggressiveness option

### DIFF
--- a/preproc.py
+++ b/preproc.py
@@ -288,6 +288,7 @@ def preprocess_pipeline(
     outdir: str,
     track_index: Optional[int] = None,
     denoise: bool = False,
+    denoise_aggressiveness: float = 0.85,
     normalize: bool = False,
     music_threshold: float = 0.5,
 ) -> Tuple[str, List[Tuple[float, float]]]:
@@ -304,6 +305,8 @@ def preprocess_pipeline(
         auto-detected.
     denoise: bool, optional
         Apply noise reduction when ``True``.
+    denoise_aggressiveness: float, optional
+        Strength for noise reduction passed to :func:`denoise_audio`.
     normalize: bool, optional
         Apply loudness normalization when ``True``.
     music_threshold: float, optional
@@ -328,7 +331,9 @@ def preprocess_pipeline(
 
     if denoise:
         denoised = os.path.join(outdir, "denoised.wav")
-        audio_path = denoise_audio(audio_path, denoised)
+        audio_path = denoise_audio(
+            audio_path, denoised, aggressiveness=denoise_aggressiveness
+        )
 
     if normalize:
         normalized = os.path.join(outdir, "normalized.wav")
@@ -354,6 +359,12 @@ def main() -> None:
         "--denoise", action="store_true", help="Apply noise reduction"
     )
     parser.add_argument(
+        "--denoise-aggressive",
+        type=float,
+        default=0.85,
+        help="Aggressiveness of noise reduction",
+    )
+    parser.add_argument(
         "--normalize", action="store_true", help="Apply loudness normalization"
     )
     parser.add_argument(
@@ -376,6 +387,7 @@ def main() -> None:
             outdir=args.outdir,
             track_index=args.track,
             denoise=args.denoise,
+            denoise_aggressiveness=args.denoise_aggressive,
             normalize=args.normalize,
             music_threshold=args.music_threshold,
         )

--- a/tests/test_preproc.py
+++ b/tests/test_preproc.py
@@ -82,6 +82,30 @@ def test_denoise_audio_passes_aggressiveness(monkeypatch, tmp_path):
     write_mock.assert_called_once_with(str(output_wav), data, rate)
 
 
+def test_preprocess_pipeline_forwards_aggressiveness(monkeypatch, tmp_path):
+    monkeypatch.setattr(preproc.os.path, "isfile", lambda p: True)
+    monkeypatch.setattr(preproc.os, "makedirs", lambda *a, **k: None)
+    monkeypatch.setattr(preproc, "find_english_track", lambda p: 0)
+
+    extract_mock = MagicMock(return_value=str(tmp_path / "audio.wav"))
+    monkeypatch.setattr(preproc, "extract_audio", extract_mock)
+
+    denoise_mock = MagicMock(return_value=str(tmp_path / "den.wav"))
+    monkeypatch.setattr(preproc, "denoise_audio", denoise_mock)
+
+    detect_mock = MagicMock(return_value=[])
+    monkeypatch.setattr(preproc, "detect_music_segments", detect_mock)
+
+    preproc.preprocess_pipeline(
+        input_path="in.mp4",
+        outdir=str(tmp_path),
+        denoise=True,
+        denoise_aggressiveness=0.9,
+    )
+
+    assert denoise_mock.call_args.kwargs["aggressiveness"] == 0.9
+
+
 def test_normalize_audio_copy_when_disabled(monkeypatch, tmp_path):
     copy_mock = MagicMock()
     monkeypatch.setattr(preproc.shutil, "copyfile", copy_mock)


### PR DESCRIPTION
## Summary
- allow tuning noise reduction via new `denoise_aggressiveness` parameter
- expose CLI flag `--denoise-aggressive` to control noise reduction strength
- test that preprocess pipeline forwards aggressiveness to denoiser

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894632a7c2883339590c7f651950591