### PR TITLE
docs: document transcription phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,64 @@ Additional options:
 - `music_segments.json` – JSON array of detected music segments in seconds,
   saved under the `--outdir` directory.
 
+## Phase-2: Transcription & Alignment
+
+`transcribe.py` converts the cleaned audio from Phase 1 into time-aligned
+segments using WhisperX.
+
+### CLI usage
+
+```bash
+python transcribe.py preproc/normalized.wav --outdir transcript \
+    --music-segments preproc/music_segments.json
+```
+
+#### Options
+
+- `audio_path` – path to the mono 16 kHz WAV produced by Phase 1 (for example,
+  `preproc/normalized.wav`).
+- `--outdir DIR` – directory where `transcript.json` and `segments.json` are
+  written.
+- `--model NAME` – Whisper model to load (default `large-v2`).
+- `--batch-size N` – batch size for both transcription and alignment
+  (default `8`).
+- `--beam-size N` – beam search width used during decoding (default `5`).
+- `--compute-type TYPE` – precision for WhisperX such as `float16` or
+  `float32` (default `float32`).
+- `--music-segments FILE` – optional JSON file with `[start, end]` pairs from
+  Phase 1 to flag music regions.
+
+### Output files
+
+- `transcript.json` – raw WhisperX segments with an additional `is_music`
+  boolean.
+- `segments.json` – simplified segments used by downstream tooling:
+
+  ```json
+  [
+    {
+      "start": 0.0,
+      "end": 3.2,
+      "text": "hello world",
+      "words": [
+        {"word": "hello", "start": 0.0, "end": 1.2},
+        {"word": "world", "start": 1.3, "end": 3.2}
+      ]
+    }
+  ]
+  ```
+
+### Full Phase 1 → Phase 2 example
+
+```bash
+# Phase 1: extract, clean, and detect music
+python preproc.py --input video.mp4 --denoise --normalize --outdir preproc
+
+# Phase 2: transcribe and align using the cleaned audio and music ranges
+python transcribe.py preproc/normalized.wav --outdir transcript \
+    --music-segments preproc/music_segments.json
+```
+
 ## Usage
 
 Activate the `subwhisper` conda environment before running any commands.

--- a/transcribe.py
+++ b/transcribe.py
@@ -1,5 +1,9 @@
 """Utilities for transcribing audio with WhisperX and word-level alignment.
 
+The script expects the mono 16 kHz WAV produced by ``preproc.py`` and,
+optionally, a ``music_segments.json`` file containing ``[start, end]`` pairs
+to mark regions with background music.
+
 The transcription pipeline writes two JSON files to the output directory:
 
 ``transcript.json``
@@ -24,6 +28,13 @@ The transcription pipeline writes two JSON files to the output directory:
 
     ``words`` is empty when a segment was skipped during alignment (e.g. for
     music sections).
+
+Command line usage::
+
+    python transcribe.py cleaned.wav --outdir transcript \
+        --music-segments preproc/music_segments.json \
+        [--model large-v2] [--batch-size 8] [--beam-size 5] \
+        [--compute-type float32]
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- document Phase-2 transcription and alignment pipeline
- describe `transcribe.py` inputs, CLI options, and JSON outputs
- show an end-to-end Phase 1 → Phase 2 example

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68949d0588048333b023d21671042724