### PR TITLE
Add subtitle formatting utility

### DIFF
--- a/format_subtitles.py
+++ b/format_subtitles.py
@@ -1,0 +1,127 @@
+"""Subtitle formatting utilities."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+
+class ConfigDict(dict):
+    """Helper dict allowing attribute access for tests."""
+
+    def __getattr__(self, item: str) -> Any:  # pragma: no cover - trivial
+        try:
+            return self[item]
+        except KeyError as exc:
+            raise AttributeError(item) from exc
+
+
+def _as_dict(config: Any) -> Dict[str, Any]:
+    """Return ``config`` as a dictionary."""
+    if isinstance(config, dict):
+        return config
+    # Try to handle SimpleNamespace or similar objects
+    return {k: getattr(config, k) for k in dir(config) if not k.startswith("__")}
+
+
+def format_subtitles(segments: List[Dict[str, Any]], config: Any) -> List[Dict[str, Any]]:
+    """Format segments into subtitle blocks.
+
+    Parameters
+    ----------
+    segments:
+        Sequence of segment dictionaries. Each segment must contain ``start``,
+        ``end``, ``text`` and optionally ``words`` and ``is_music``.
+    config:
+        Mapping or object providing ``max_line_length``, ``max_line_count``,
+        ``max_duration``, ``skip_music`` and ``gap``.
+
+    Returns
+    -------
+    list of dict
+        Subtitle blocks with ``start``, ``end`` and ``lines`` keys.
+    """
+    cfg = _as_dict(config)
+    max_line_length = int(cfg["max_line_length"])
+    max_line_count = int(cfg["max_line_count"])
+    max_duration = float(cfg["max_duration"])
+    skip_music = bool(cfg.get("skip_music", False))
+    merge_gap = float(cfg.get("gap", 0.0))
+
+    results: List[Dict[str, Any]] = []
+
+    current_lines: List[str] = []
+    current_line = ""
+    block_start: float | None = None
+    block_end: float | None = None
+
+    def finalize() -> None:
+        nonlocal current_lines, current_line, block_start, block_end
+        if block_start is None:
+            return
+        if current_line:
+            current_lines.append(current_line)
+        start = block_start
+        if results:
+            prev_end = results[-1]["end"]
+            if start < prev_end + 0.1:
+                start = prev_end + 0.1
+        results.append({"start": start, "end": block_end, "lines": current_lines})
+        current_lines = []
+        current_line = ""
+        block_start = None
+        block_end = None
+
+    for seg in segments:
+        if skip_music and seg.get("is_music"):
+            continue
+        words = seg.get("words") or []
+        if not words:
+            words = [{"word": seg.get("text", ""), "start": seg["start"], "end": seg["end"]}]
+
+        for word in words:
+            w_text = word.get("word", "").strip()
+            if not w_text:
+                continue
+            w_start = float(word.get("start", seg["start"]))
+            w_end = float(word.get("end", w_start))
+
+            if block_start is None:
+                block_start = w_start
+                current_line = w_text
+                block_end = w_end
+                continue
+
+            # start new block when gap between words is large
+            if w_start - block_end > merge_gap:
+                finalize()
+                block_start = w_start
+                current_line = w_text
+                block_end = w_end
+                continue
+
+            # start new block if adding word exceeds max duration
+            if w_end - block_start > max_duration:
+                finalize()
+                block_start = w_start
+                current_line = w_text
+                block_end = w_end
+                continue
+
+            # try to append to current line
+            candidate = f"{current_line} {w_text}" if current_line else w_text
+            if len(candidate) <= max_line_length:
+                current_line = candidate
+                block_end = w_end
+            else:
+                # line full -> push current line to lines
+                current_lines.append(current_line)
+                if len(current_lines) >= max_line_count:
+                    finalize()
+                    block_start = w_start
+                    current_line = w_text
+                    block_end = w_end
+                else:
+                    current_line = w_text
+                    block_end = w_end
+
+    finalize()
+    return results

--- a/tests/test_format_subtitles.py
+++ b/tests/test_format_subtitles.py
@@ -1,0 +1,121 @@
+import sys
+import pathlib
+from types import SimpleNamespace
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from format_subtitles import format_subtitles
+
+
+def test_merge_and_line_split():
+    segments = [
+        {
+            "start": 0.0,
+            "end": 1.0,
+            "text": "hello world",
+            "words": [
+                {"word": "hello", "start": 0.0, "end": 0.5},
+                {"word": "world", "start": 0.5, "end": 1.0},
+            ],
+        },
+        {
+            "start": 1.05,
+            "end": 2.0,
+            "text": "how are you",
+            "words": [
+                {"word": "how", "start": 1.05, "end": 1.3},
+                {"word": "are", "start": 1.3, "end": 1.6},
+                {"word": "you", "start": 1.6, "end": 2.0},
+            ],
+        },
+    ]
+    cfg = SimpleNamespace(
+        max_line_length=11,
+        max_line_count=2,
+        max_duration=10.0,
+        skip_music=False,
+        gap=0.3,
+    )
+    blocks = format_subtitles(segments, cfg)
+    assert blocks == [
+        {
+            "start": 0.0,
+            "end": 2.0,
+            "lines": ["hello world", "how are you"],
+        }
+    ]
+
+
+def test_max_duration_and_gap():
+    segments = [
+        {
+            "start": 0.0,
+            "end": 2.0,
+            "text": "one two three four",
+            "words": [
+                {"word": "one", "start": 0.0, "end": 0.5},
+                {"word": "two", "start": 0.5, "end": 1.0},
+                {"word": "three", "start": 1.0, "end": 1.5},
+                {"word": "four", "start": 1.5, "end": 2.0},
+            ],
+        },
+        {
+            "start": 2.05,
+            "end": 4.5,
+            "text": "five six seven eight",
+            "words": [
+                {"word": "five", "start": 2.05, "end": 2.5},
+                {"word": "six", "start": 2.5, "end": 3.0},
+                {"word": "seven", "start": 3.0, "end": 3.5},
+                {"word": "eight", "start": 3.5, "end": 4.5},
+            ],
+        },
+    ]
+    cfg = SimpleNamespace(
+        max_line_length=20,
+        max_line_count=2,
+        max_duration=2.0,
+        skip_music=False,
+        gap=0.1,
+    )
+    blocks = format_subtitles(segments, cfg)
+    assert [b["lines"] for b in blocks] == [
+        ["one two three four"],
+        ["five six seven"],
+        ["eight"],
+    ]
+    assert blocks[0]["end"] == pytest.approx(2.0)
+    # second block starts at least 0.1s after first ends
+    assert blocks[1]["start"] == pytest.approx(2.1)
+    # third block also respects gap
+    assert blocks[2]["start"] == pytest.approx(3.6)
+
+
+def test_skip_music_segments():
+    segments = [
+        {
+            "start": 0.0,
+            "end": 1.0,
+            "text": "speech",
+            "words": [{"word": "speech", "start": 0.0, "end": 1.0}],
+        },
+        {
+            "start": 1.5,
+            "end": 2.5,
+            "text": "music",
+            "is_music": True,
+            "words": [],
+        },
+    ]
+    cfg = SimpleNamespace(
+        max_line_length=20,
+        max_line_count=2,
+        max_duration=5.0,
+        skip_music=True,
+        gap=0.1,
+    )
+    blocks = format_subtitles(segments, cfg)
+    assert blocks == [{"start": 0.0, "end": 1.0, "lines": ["speech"]}]


### PR DESCRIPTION
## Summary
- implement `format_subtitles` to split/merge Whisper segments into timed subtitle blocks
- add tests validating line length, duration limits, gap enforcement and music skipping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894c0069e6483338c54e64175cfe14d