### PR TITLE
feat: enforce subtitle limits

### DIFF
--- a/subtitle_pipeline.py
+++ b/subtitle_pipeline.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 import pysubs2
+import textwrap
 
 
 def load_segments(path: Path) -> pysubs2.SSAFile:
@@ -32,3 +33,70 @@ def load_segments(path: Path) -> pysubs2.SSAFile:
         data = data["segments"]
 
     return pysubs2.load_from_whisper(data)
+
+
+def enforce_limits(
+    subs: pysubs2.SSAFile,
+    max_chars: int,
+    max_lines: int,
+    max_duration: float,
+    min_gap: float,
+) -> pysubs2.SSAFile:
+    """Enforce basic formatting limits on ``subs`` in-place.
+
+    Parameters
+    ----------
+    subs:
+        Subtitle collection to mutate.
+    max_chars:
+        Maximum characters allowed per line.
+    max_lines:
+        Maximum number of lines per event.
+    max_duration:
+        Maximum duration for a single event in seconds.
+    min_gap:
+        Minimum required gap between consecutive events in seconds.
+
+    Returns
+    -------
+    pysubs2.SSAFile
+        The modified subtitle file (same object as ``subs``).
+    """
+
+    max_ms = int(max_duration * 1000)
+    gap_ms = int(min_gap * 1000)
+
+    # First, wrap the text of each event and clip overly long durations.
+    for ev in subs.events:
+        lines = textwrap.wrap(ev.plaintext, width=max_chars)
+        if len(lines) > max_lines:
+            lines = lines[:max_lines]
+        ev.text = "\\N".join(lines)
+        if ev.end - ev.start > max_ms:
+            ev.end = ev.start + max_ms
+
+    # Then enforce minimum gaps and re-check durations. Merge events that
+    # would end up empty after shifting for the gap.
+    i = 1
+    while i < len(subs.events):
+        prev = subs.events[i - 1]
+        curr = subs.events[i]
+        required_start = prev.end + gap_ms
+        if curr.start < required_start:
+            curr.start = required_start
+            if curr.start >= curr.end:
+                prev.text = prev.plaintext + "\\N" + curr.plaintext
+                prev.end = max(prev.end, curr.end)
+                subs.events.pop(i)
+                lines = textwrap.wrap(prev.plaintext, width=max_chars)
+                if len(lines) > max_lines:
+                    lines = lines[:max_lines]
+                prev.text = "\\N".join(lines)
+                if prev.end - prev.start > max_ms:
+                    prev.end = prev.start + max_ms
+                continue
+        if curr.end - curr.start > max_ms:
+            curr.end = curr.start + max_ms
+        i += 1
+
+    return subs

--- a/tests/test_enforce_limits.py
+++ b/tests/test_enforce_limits.py
@@ -1,0 +1,36 @@
+import sys
+import pathlib
+import pysubs2
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from subtitle_pipeline import enforce_limits
+
+
+def make_event(start, end, text):
+    return pysubs2.SSAEvent(start=start, end=end, text=text)
+
+
+def test_wrap_and_truncate_lines():
+    subs = pysubs2.SSAFile()
+    subs.events.append(make_event(0, 1000, "hello world it's me"))
+    enforce_limits(subs, max_chars=5, max_lines=2, max_duration=10.0, min_gap=0.0)
+    assert subs.events[0].text == "hello\\Nworld"
+
+
+def test_clip_duration():
+    subs = pysubs2.SSAFile()
+    subs.events.append(make_event(0, 7000, "long"))
+    enforce_limits(subs, max_chars=20, max_lines=1, max_duration=2.0, min_gap=0.0)
+    assert subs.events[0].end == 2000
+
+
+def test_insert_gap():
+    subs = pysubs2.SSAFile()
+    subs.events.append(make_event(0, 1000, "first"))
+    subs.events.append(make_event(1100, 2000, "second"))
+    enforce_limits(subs, max_chars=20, max_lines=1, max_duration=5.0, min_gap=0.5)
+    assert subs.events[1].start == 1500


### PR DESCRIPTION
## Summary
- add enforce_limits helper to wrap lines, cap duration, and enforce gaps on SSA subtitles
- include tests covering wrapping, duration clipping, and gap insertion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894c98ca3188333b4ae9b7a50462263