### PR TITLE
Add WER quality control utility

### DIFF
--- a/qc.py
+++ b/qc.py
@@ -1,0 +1,69 @@
+"""Quality control utilities."""
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+from pathlib import Path
+from typing import Iterable
+
+import jiwer
+import pysubs2
+
+logger = logging.getLogger(__name__)
+
+
+def _strip_markup(text: str) -> str:
+    """Remove simple markup tags from ``text``."""
+    return re.sub(r"<[^>]+>", "", text)
+
+
+def _load_text(path: Path) -> str:
+    """Load subtitle or plain text from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Location of ``.srt`` or ``.txt`` file.
+    """
+    if path.suffix.lower() == ".srt":
+        subs = pysubs2.load(str(path))
+        return " ".join(event.plaintext for event in subs)
+    if path.suffix.lower() == ".txt":
+        return _strip_markup(path.read_text(encoding="utf-8"))
+    raise ValueError(f"Unsupported file type: {path.suffix}")
+
+
+def compute_wer(hyp_path: str, ref_path: str) -> float:
+    """Compute word error rate between two files.
+
+    Parameters
+    ----------
+    hyp_path, ref_path:
+        Paths to the hypothesis and reference files.
+
+    Returns
+    -------
+    float
+        The word error rate between ``hyp_path`` and ``ref_path``.
+    """
+    hyp = _load_text(Path(hyp_path))
+    ref = _load_text(Path(ref_path))
+    score = jiwer.wer(ref, hyp)
+    logger.info("WER(%s, %s) = %.3f", hyp_path, ref_path, score)
+    return score
+
+
+def main(argv: Iterable[str] | None = None) -> float:
+    """Command-line interface for :func:`compute_wer`."""
+    parser = argparse.ArgumentParser(description="Compute word error rate")
+    parser.add_argument("hyp")
+    parser.add_argument("ref")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO)
+    return compute_wer(args.hyp, args.ref)
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience CLI
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ librosa>=0.10
 noisereduce>=3.0
 packaging
 rich
+jiwer
 pyyaml
 language_tool_python

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -1,0 +1,25 @@
+import pytest
+
+from qc import compute_wer
+
+
+def test_compute_wer_txt(tmp_path):
+    ref = tmp_path / "ref.txt"
+    ref.write_text("hello world")
+    hyp = tmp_path / "hyp.txt"
+    hyp.write_text("hello there world")
+    assert compute_wer(str(hyp), str(ref)) == pytest.approx(0.5)
+
+
+def test_compute_wer_srt(tmp_path):
+    ref = tmp_path / "ref.srt"
+    ref.write_text(
+        "1\n00:00:00,000 --> 00:00:01,000\n<i>Hello</i> world\n\n",
+        encoding="utf-8",
+    )
+    hyp = tmp_path / "hyp.srt"
+    hyp.write_text(
+        "1\n00:00:00,000 --> 00:00:01,000\n<i>Hello</i> there world\n\n",
+        encoding="utf-8",
+    )
+    assert compute_wer(str(hyp), str(ref)) == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- add qc module with compute_wer function that loads .txt/.srt files, strips markup, and computes WER using jiwer
- expose compute_wer via simple CLI
- include unit tests for .txt and .srt inputs and add jiwer dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894f602b9988333aebd57a48a0a7b76