### PR TITLE
Add subtitle sync validation using aeneas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ rich
 jiwer
 pyyaml
 language_tool_python
+aeneas


### PR DESCRIPTION
## Summary
- add `validate_sync` to force-align subtitle text to audio with aeneas and compute offset metrics
- expose sync validation via new `sync` CLI command
- include aeneas dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894f8ce737883338f33b942ac142a4f