### PR TITLE
Add subtitle metrics collection and tests

### DIFF
--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -1,6 +1,12 @@
 import pytest
+import pathlib
+import sys
 
-from qc import compute_wer
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from qc import collect_metrics, compute_wer
 
 
 def test_compute_wer_txt(tmp_path):
@@ -23,3 +29,17 @@ def test_compute_wer_srt(tmp_path):
         encoding="utf-8",
     )
     assert compute_wer(str(hyp), str(ref)) == pytest.approx(0.5)
+
+
+def test_collect_metrics(tmp_path):
+    srt = tmp_path / "test.srt"
+    srt.write_text(
+        "1\n00:00:00,000 --> 00:00:01,000\nHello\nWorld\n\n"
+        "2\n00:00:01,000 --> 00:00:03,000\nAnother line\n\n",
+        encoding="utf-8",
+    )
+    metrics = collect_metrics(str(srt))
+    assert metrics["subtitle_count"] == 2
+    assert metrics["avg_duration"] == pytest.approx(1.5)
+    assert metrics["avg_lines"] == pytest.approx(1.5)
+    assert metrics["warnings"] == []


### PR DESCRIPTION
## Summary
- add collect_metrics to summarize subtitle counts, duration, line counts, and warnings
- test metrics collection and path setup in qc tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894fbf34fb08333b910cd661500bbcc