### PR TITLE
Add jiwer and aeneas dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,3 +22,5 @@ dependencies:
       - rich             # pretty logging in the terminal
       - pyyaml
       - language_tool_python
+      - jiwer>=3.0
+      - aeneas>=1.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ librosa>=0.10
 noisereduce>=3.0
 packaging
 rich
-jiwer
+jiwer>=3.0
 pyyaml
 language_tool_python
-aeneas
+aeneas>=1.7.3


### PR DESCRIPTION
## Summary
- specify `jiwer>=3.0` and `aeneas>=1.7.3` in requirements and Conda environment

## Testing
- `pytest -q`
- `pip install --no-build-isolation aeneas>=1.7.3` *(fails: "You must install numpy before installing aeneas")*

------
https://chatgpt.com/codex/tasks/task_e_689500f810308333a696bdab882e9832