### PR TITLE
Add run summary and rerun support for failed episodes

### DIFF
--- a/rerun_failed.py
+++ b/rerun_failed.py
@@ -1,0 +1,43 @@
+import csv
+import json
+from pathlib import Path
+from typing import List
+
+from experiment import SubtitleExperiment
+
+
+def main() -> None:
+    failed_path = Path("failed.csv")
+    if not failed_path.exists():
+        print("No failed episodes found")
+        return
+
+    with failed_path.open("r", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        rows = list(reader)
+
+    remaining: List[dict] = []
+    for row in rows:
+        cfg = json.loads(row["config"])
+        cfg["inputs"] = [row["file"]]
+        cfg["run_id"] = f"{row['run_id']}_retry"
+        exp = SubtitleExperiment(cfg)
+        try:
+            exp.run()
+            exp.aggregate_results()
+            exp.report()
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"Rerun failed for {row['file']}: {exc}")
+            remaining.append(row)
+
+    if remaining:
+        with failed_path.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=reader.fieldnames)
+            writer.writeheader()
+            writer.writerows(remaining)
+    else:
+        failed_path.unlink()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- generate run-level summary markdown with metrics and best parameter set table
- track per-episode failure and record to `failed.csv`
- add `rerun_failed.py` to re-execute failed episodes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68957678c25c8333834f9fbbb13f8b6e