### PR TITLE
Add Airflow pipeline DAG and deployment docs

### DIFF
--- a/airflow/pipeline_dag.py
+++ b/airflow/pipeline_dag.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.utils.email import send_email
+
+from experiment import SubtitleExperiment
+
+log = logging.getLogger(__name__)
+
+
+def _run_experiment(**context: Dict[str, Any]) -> None:
+    """Run ``SubtitleExperiment`` with parameters from the DAG run."""
+    params: Dict[str, Any] = context.get("dag_run").conf or {}
+    log.info("Starting SubtitleExperiment with params: %s", params)
+    exp = SubtitleExperiment(params)
+    exp.run()
+
+
+def _notify_failure(context: Dict[str, Any]) -> None:  # pragma: no cover - Airflow callback
+    """Send an email notification when the task or DAG fails."""
+    subject = f"DAG {context['dag'].dag_id} failed"
+    body = f"Run {context['run_id']} failed. See logs for details."
+    send_email(to="alerts@example.com", subject=subject, html_content=body)
+
+
+default_args = {
+    "owner": "airflow",
+    "retries": 2,
+    "retry_delay": timedelta(minutes=5),
+}
+
+with DAG(
+    dag_id="subtitle_pipeline",
+    description="Run SubWhisper subtitle experiments",
+    default_args=default_args,
+    schedule_interval=None,
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+    on_failure_callback=_notify_failure,
+) as dag:
+    run_experiment = PythonOperator(
+        task_id="run_experiment",
+        python_callable=_run_experiment,
+    )

--- a/docs/airflow.md
+++ b/docs/airflow.md
@@ -1,0 +1,23 @@
+# Airflow DAG Deployment
+
+This project ships with an example DAG for running subtitle experiments
+in [Apache Airflow](https://airflow.apache.org/).
+
+## Deploying the DAG
+
+1. **Install dependencies**
+   Ensure Airflow is installed and running. Copy any runtime dependencies from
+   `requirements.txt` into your Airflow environment.
+2. **Place the DAG file**
+   Copy or symlink `airflow/pipeline_dag.py` into your Airflow instance's `dags/`
+   directory so that it is discovered by the scheduler.
+3. **Configure notifications**
+   Update the `alerts@example.com` address in the DAG to the email used for
+   failure notifications.
+4. **Run the DAG**
+   Trigger the DAG manually from the Airflow UI or CLI. Provide a JSON
+   configuration matching the `SubtitleExperiment` parameters to the run to
+   customize each execution.
+
+The DAG will retry failed runs twice and send an email notification if the run
+ultimately fails.


### PR DESCRIPTION
## Summary
- Add `airflow/pipeline_dag.py` DAG that runs `SubtitleExperiment`, retries tasks and emails on failure
- Document how to deploy the DAG in `docs/airflow.md`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pysubs2')*


------
https://chatgpt.com/codex/tasks/task_e_689581f691f48333ae6447d899557415