### PR TITLE
Store git hash, env snapshot, and add rollback utility

### DIFF
--- a/rollback.py
+++ b/rollback.py
@@ -1,0 +1,43 @@
+import argparse
+import shutil
+from pathlib import Path
+
+
+def restore(run_id: str, output_root: str = "runs", dest: str = "restored") -> None:
+    """Copy SRT outputs from a previous run into ``dest``.
+
+    Parameters
+    ----------
+    run_id:
+        Identifier of the run to restore from.
+    output_root:
+        Root directory containing run subdirectories.
+    dest:
+        Destination directory where files will be copied.
+    """
+    run_dir = Path(output_root) / run_id
+    if not run_dir.exists():
+        raise FileNotFoundError(f"Run directory {run_dir} does not exist")
+
+    dest_dir = Path(dest)
+    count = 0
+    for srt in run_dir.glob("**/*.srt"):
+        rel = srt.relative_to(run_dir)
+        target = dest_dir / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(srt, target)
+        count += 1
+    print(f"Restored {count} files to {dest_dir}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Restore outputs from a previous run")
+    parser.add_argument("--run-id", required=True, help="Run identifier to restore")
+    parser.add_argument("--output-root", default="runs", help="Root directory containing runs")
+    parser.add_argument("--dest", default="restored", help="Directory to copy outputs into")
+    args = parser.parse_args()
+    restore(args.run_id, args.output_root, args.dest)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -59,6 +59,10 @@ def test_run_logging_and_aggregation(tmp_path, monkeypatch):
     exp = SubtitleExperiment(cfg)
     run_dir = Path(cfg["output_root"]) / cfg["run_id"]
     cfg_path = run_dir / f"config_{cfg['run_id']}.json"
+    commit_path = run_dir / f"commit_{cfg['run_id']}.txt"
+    reqs_path = run_dir / "requirements.txt"
+    assert commit_path.exists()
+    assert reqs_path.exists()
     assert not cfg_path.exists()
 
     exp.run()
@@ -82,6 +86,8 @@ def test_run_logging_and_aggregation(tmp_path, monkeypatch):
     assert rows[0]["run_id"] == cfg["run_id"]
     loaded_cfg = json.loads(rows[0]["config"])
     assert loaded_cfg["run_id"] == cfg["run_id"]
+    commit_val = commit_path.read_text().strip()
+    assert loaded_cfg["git_commit"] == commit_val
     assert float(rows[0]["avg_subtitle_count"]) == 1
 
     summary_md = run_dir / "summary.md"
@@ -212,9 +218,13 @@ def test_parameter_sweep_outputs_and_aggregation(tmp_path, monkeypatch):
         cfg_file = run_dir / f"config_{run_id}.json"
         metrics_file = run_dir / f"metrics_{run_id}.json"
         log_file = run_dir / "run.log"
+        commit_file = run_dir / f"commit_{run_id}.txt"
+        req_file = run_dir / "requirements.txt"
         assert cfg_file.exists()
         assert metrics_file.exists()
         assert log_file.exists()
+        assert commit_file.exists()
+        assert req_file.exists()
         metrics = json.loads(metrics_file.read_text())
         assert metrics[0]["subtitle_count"] == 1
 

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from rollback import restore
+
+
+def test_restore_copies_srt(tmp_path):
+    run_id = "oldrun"
+    output_root = tmp_path / "runs"
+    src_dir = output_root / run_id / "episode"
+    src_dir.mkdir(parents=True)
+    srt_file = src_dir / f"episode_{run_id}.srt"
+    srt_file.write_text("data", encoding="utf-8")
+
+    dest = tmp_path / "restored"
+    restore(run_id, str(output_root), str(dest))
+
+    restored = dest / "episode" / f"episode_{run_id}.srt"
+    assert restored.exists()
+    assert restored.read_text() == "data"


### PR DESCRIPTION
## Summary
- Capture current git commit and pip requirements during `SubtitleExperiment` setup
- Add `rollback.py` script to restore SRT outputs from previous runs
- Test coverage for new run metadata and rollback behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689583bd7e00833383a4c7bddfd31680