### PR TITLE
feat: add review endpoint

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
 import argparse
+import json
+import logging
 import shutil
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict
 
+import pysubs2
 from fastapi import BackgroundTasks, FastAPI, HTTPException
 from fastapi.responses import FileResponse
 
+from corrections import apply_corrections, load_corrections
 from experiment import SubtitleExperiment
 
 app = FastAPI()
@@ -78,6 +83,89 @@ def download(run_id: str) -> FileResponse:
     if not zip_path.exists():
         shutil.make_archive(str(run_dir), "zip", run_dir)
     return FileResponse(zip_path, filename=f"{run_dir.name}.zip")
+
+
+@app.get("/review/{run_id}")
+def review(run_id: str) -> Dict[str, Any]:
+    """Return current subtitle files for ``run_id``."""
+    info = RUNS.get(run_id)
+    if not info:
+        raise HTTPException(status_code=404, detail="run_id not found")
+    run_dir = Path(info["run_dir"])
+    if not run_dir.exists():
+        raise HTTPException(status_code=404, detail="run directory missing")
+    subtitles: Dict[str, str] = {}
+    for path in run_dir.rglob("*.srt"):
+        try:
+            subtitles[str(path.relative_to(run_dir))] = path.read_text(
+                encoding="utf-8"
+            )
+        except Exception:  # pragma: no cover - defensive
+            continue
+    return {"run_id": run_id, "subtitles": subtitles}
+
+
+@app.post("/review/{run_id}")
+def submit_review(run_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Accept corrections and reapply them to subtitle files.
+
+    The request body should contain a ``corrections`` mapping and optional
+    ``reviewer`` metadata. Corrections are merged into
+    ``runs/<run_id>/corrections.json`` and immediately applied to all SRT
+    files under the run directory. Each submission is appended to
+    ``review_log.jsonl`` for auditing.
+    """
+
+    info = RUNS.get(run_id)
+    if not info:
+        raise HTTPException(status_code=404, detail="run_id not found")
+    run_dir = Path(info["run_dir"])
+    if not run_dir.exists():
+        raise HTTPException(status_code=404, detail="run directory missing")
+
+    corrections = payload.get("corrections")
+    if not isinstance(corrections, dict) or not corrections:
+        raise HTTPException(status_code=400, detail="corrections mapping required")
+    reviewer = payload.get("reviewer", {})
+
+    corr_path = run_dir / "corrections.json"
+    if corr_path.exists():
+        try:
+            existing = json.loads(corr_path.read_text(encoding="utf-8"))
+        except Exception:  # pragma: no cover - defensive
+            existing = {}
+    else:
+        existing = {}
+    existing.update({str(k): str(v) for k, v in corrections.items()})
+    corr_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+
+    log_entry = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "reviewer": reviewer,
+        "changes": corrections,
+    }
+    with (run_dir / "review_log.jsonl").open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(log_entry) + "\n")
+
+    try:
+        rules = load_corrections(corr_path)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    for srt_path in run_dir.rglob("*.srt"):
+        try:
+            subs = pysubs2.load(str(srt_path))
+            for ev in subs.events:
+                fixed = apply_corrections(ev.plaintext, rules)
+                ev.text = fixed.replace("\n", "\\N")
+            subs.save(str(srt_path), format_="srt")
+        except Exception:  # pragma: no cover - defensive
+            continue
+
+    logging.getLogger(__name__).info(
+        "review submitted for %s by %s", run_id, reviewer or "unknown"
+    )
+    return {"run_id": run_id, "applied": len(corrections)}
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_api_review.py
+++ b/tests/test_api_review.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from api import RUNS, app
+
+
+def _setup_run(tmp_path: Path):
+    run_id = "test_run"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir()
+    srt_path = run_dir / "sample.srt"
+    srt_path.write_text(
+        "1\n00:00:00,000 --> 00:00:01,000\nteh cat\n", encoding="utf-8"
+    )
+    (run_dir / "run.log").write_text("", encoding="utf-8")
+    RUNS[run_id] = {
+        "status": "completed",
+        "run_dir": str(run_dir),
+        "log_file": str(run_dir / "run.log"),
+    }
+    return run_id, srt_path
+
+
+def test_review_roundtrip(tmp_path: Path):
+    run_id, srt_path = _setup_run(tmp_path)
+    client = TestClient(app)
+
+    resp = client.get(f"/review/{run_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "sample.srt" in data["subtitles"]
+    assert "teh cat" in data["subtitles"]["sample.srt"]
+
+    payload = {"corrections": {"teh": "the"}, "reviewer": {"name": "Bob"}}
+    resp = client.post(f"/review/{run_id}", json=payload)
+    assert resp.status_code == 200
+    assert resp.json()["applied"] == 1
+
+    updated = srt_path.read_text(encoding="utf-8")
+    assert "the cat" in updated
+
+    corr_file = Path(RUNS[run_id]["run_dir"]) / "corrections.json"
+    assert json.loads(corr_file.read_text(encoding="utf-8"))["teh"] == "the"
+
+    log_lines = (
+        Path(RUNS[run_id]["run_dir"]) / "review_log.jsonl"
+    ).read_text(encoding="utf-8").strip().splitlines()
+    assert json.loads(log_lines[-1])["reviewer"]["name"] == "Bob"
+
+    RUNS.clear()


### PR DESCRIPTION
## Summary
- expose review route to fetch and update run subtitles
- log reviewer corrections and reapply them to subtitle files
- exercise review workflow with a new test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895887e6634833381a1dbccde3feafd