### PR TITLE
Add token-based authentication for FastAPI endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,28 @@ separate voice‑activity detection (VAD) step if you need to trim silence.
 The goal is to provide an easily hackable starting point for automated
 subtitle workflows.
 
+## API Authentication
+
+The accompanying FastAPI server secures its endpoints with simple
+token-based authentication. Tokens and their associated roles are stored in
+an `auth.yaml` file located next to `api.py`:
+
+```yaml
+tokens:
+  my-admin-token: admin
+  read-only-token: viewer
+```
+
+Clients must send the token in the `Authorization` header using the
+`Bearer <token>` scheme. Two roles are recognized:
+
+- `admin` – start runs and submit subtitle reviews.
+- `viewer` – read-only access for status checks, downloads and viewing
+  current subtitles.
+
+Edit `auth.yaml` to add or revoke credentials and restart the server to
+apply changes.
+
 ## Installation Prerequisites
 
 The script relies on a few external tools and Python packages. It has been

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,30 @@
+import yaml
+from pathlib import Path
+from typing import Dict, Callable
+from fastapi import Depends, HTTPException, Header
+
+AUTH_FILE = Path(__file__).with_name("auth.yaml")
+
+def _load_tokens() -> Dict[str, str]:
+    if AUTH_FILE.exists():
+        data = yaml.safe_load(AUTH_FILE.read_text()) or {}
+        return data.get("tokens", {})
+    return {}
+
+TOKENS = _load_tokens()
+
+def get_role(authorization: str | None = Header(None)) -> str:
+    prefix = "Bearer "
+    if not authorization or not authorization.startswith(prefix):
+        raise HTTPException(status_code=401, detail="Invalid authorization header")
+    token = authorization[len(prefix):]
+    role = TOKENS.get(token)
+    if not role:
+        raise HTTPException(status_code=403, detail="Invalid token")
+    return role
+
+def require_role(*allowed: str) -> Callable:
+    def dependency(role: str = Depends(get_role)) -> None:
+        if role not in allowed:
+            raise HTTPException(status_code=403, detail="Insufficient permissions")
+    return dependency

--- a/auth.yaml
+++ b/auth.yaml
@@ -1,0 +1,3 @@
+tokens:
+  test-token: admin
+  viewer-token: viewer


### PR DESCRIPTION
## Summary
- implement token/role loading from `auth.yaml`
- enforce per-endpoint permissions via FastAPI dependencies
- document credentials management in README and update API tests

## Testing
- `pytest tests/test_api_review.py`
- `pytest` *(fails: No module named 'pysubs2')*


------
https://chatgpt.com/codex/tasks/task_e_68958d5d26c8833394e1c6ffdbd736c0