### PR TITLE
Add maintenance script for pruning and archiving run outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,12 +399,44 @@ The CLI exposes a number of switches for customising behaviour:
 - `--strip-punctuation`: remove punctuation from subtitle text
 - `--language`: override language detection with a code like `en` (default: auto)
 
+## Maintenance
+
+Old run outputs can accumulate over time. The `maintenance.py` helper removes
+large intermediate files and archives completed runs to save space. By default
+it performs a dry run and simply reports the actions:
+
+```bash
+python maintenance.py --output-root runs --days 30
+```
+
+Pass `--delete` to apply the deletions after creating `.tar.gz` archives:
+
+```bash
+python maintenance.py --output-root runs --days 30 --delete
+```
+
+### Scheduling
+
+To run the cleanup periodically with cron:
+
+```cron
+0 2 * * * /usr/bin/python /path/to/maintenance.py --output-root /data/output --days 30 --delete
+```
+
+In Airflow, a `BashOperator` can invoke the script on a schedule:
+
+```python
+BashOperator(
+    task_id="subwhisper_maintenance",
+    bash_command="python /path/to/maintenance.py --output-root /data/output --days 30 --delete",
+)
+```
+
 ## Potential Enhancements
 
 - Integrate speaker diarization for multi‑speaker videos
 - Generate word‑level timestamps or translation
 - Parallelise processing across multiple GPUs
-- Automatically clean up temporary audio files
 
 ## Troubleshooting Tips
 

--- a/maintenance.py
+++ b/maintenance.py
@@ -1,0 +1,134 @@
+import argparse
+import logging
+import shutil
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+DEFAULT_PATTERNS = ("*.wav", "*.mp3", "*.json", "*.npy", "*.pt")
+
+
+def prune_raw_intermediates(
+    output_root: str = "runs",
+    patterns: Iterable[str] = DEFAULT_PATTERNS,
+    dry_run: bool = True,
+) -> int:
+    """Remove intermediate files from ``output_root``.
+
+    Parameters
+    ----------
+    output_root:
+        Root directory containing run outputs.
+    patterns:
+        Glob patterns of files to remove.
+    dry_run:
+        When ``True``, only log planned removals.
+
+    Returns
+    -------
+    int
+        Number of files removed or that would be removed.
+    """
+    root = Path(output_root)
+    count = 0
+    for pattern in patterns:
+        for path in root.rglob(pattern):
+            if dry_run:
+                logger.info("Would remove %s", path)
+            else:
+                try:
+                    path.unlink()
+                except FileNotFoundError:
+                    continue
+            count += 1
+    return count
+
+
+def compress_old_runs(
+    output_root: str = "runs",
+    days: int = 30,
+    dry_run: bool = True,
+) -> int:
+    """Archive run directories older than ``days`` days.
+
+    Parameters
+    ----------
+    output_root:
+        Root directory containing run subdirectories.
+    days:
+        Age threshold in days for compression.
+    dry_run:
+        When ``True``, only log actions without modifying files.
+
+    Returns
+    -------
+    int
+        Number of run directories archived or that would be archived.
+    """
+    root = Path(output_root)
+    if not root.exists():
+        logger.warning("Output root %s does not exist", root)
+        return 0
+    threshold = datetime.now() - timedelta(days=days)
+    count = 0
+    for run_dir in root.iterdir():
+        if not run_dir.is_dir():
+            continue
+        mtime = datetime.fromtimestamp(run_dir.stat().st_mtime)
+        if mtime > threshold:
+            continue
+        archive = run_dir.with_suffix(".tar.gz")
+        logger.info("Compressing %s to %s", run_dir, archive)
+        if dry_run:
+            count += 1
+            continue
+        shutil.make_archive(str(run_dir), "gztar", root_dir=run_dir)
+        shutil.rmtree(run_dir)
+        count += 1
+    return count
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compress old run outputs and prune intermediate files"
+    )
+    parser.add_argument(
+        "--output-root",
+        default="runs",
+        help="Root directory containing run outputs",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        help="Compress runs older than this many days",
+    )
+    parser.add_argument(
+        "--patterns",
+        nargs="+",
+        default=list(DEFAULT_PATTERNS),
+        help="Glob patterns of intermediate files to remove",
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview actions without modifying files",
+    )
+    group.add_argument(
+        "--delete",
+        action="store_true",
+        help="Delete files after compression and pruning",
+    )
+    args = parser.parse_args()
+    dry_run = not args.delete
+
+    prune_raw_intermediates(args.output_root, args.patterns, dry_run=dry_run)
+    compress_old_runs(args.output_root, args.days, dry_run=dry_run)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import os
+import tarfile
+import time
+
+from maintenance import prune_raw_intermediates, compress_old_runs
+
+
+def test_prune_removes_intermediate_files(tmp_path):
+    runs = tmp_path / "runs"
+    run_dir = runs / "r1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "audio.wav").write_text("a", encoding="utf-8")
+    (run_dir / "keep.srt").write_text("b", encoding="utf-8")
+
+    removed = prune_raw_intermediates(str(runs), patterns=["*.wav"], dry_run=False)
+    assert removed == 1
+    assert not (run_dir / "audio.wav").exists()
+    assert (run_dir / "keep.srt").exists()
+
+
+def test_compress_old_runs(tmp_path):
+    runs = tmp_path / "runs"
+    run_dir = runs / "r1"
+    run_dir.mkdir(parents=True)
+    (run_dir / "out.srt").write_text("data", encoding="utf-8")
+    (run_dir / "audio.wav").write_text("raw", encoding="utf-8")
+    old_time = time.time() - 40 * 86400
+    os.utime(run_dir, (old_time, old_time))
+
+    prune_raw_intermediates(str(runs), patterns=["*.wav"], dry_run=False)
+    count = compress_old_runs(str(runs), days=30, dry_run=False)
+    assert count == 1
+    archive = runs / "r1.tar.gz"
+    assert archive.exists()
+    assert not run_dir.exists()
+    with tarfile.open(archive) as tar:
+        names = tar.getnames()
+    assert "audio.wav" not in names


### PR DESCRIPTION
## Summary
- add `maintenance.py` to prune intermediate files and archive old runs
- document cron/Airflow scheduling and cleanup workflow in README
- cover maintenance utilities with basic tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6895942f94288333b78a8739de929e46