### PR TITLE
Add API and maintenance tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install fastapi pysubs2 pyyaml numpy jiwer librosa noisereduce soundfile httpx pytest
+      - name: Run tests
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -448,13 +448,19 @@ BashOperator(
 
 ## Running Tests
 
-The project includes a small pytest suite with mocked dependencies. To run
-the tests, execute:
+The project includes a pytest suite with mocked dependencies. To run all tests
+locally:
 
 ```bash
 pytest
 ```
 
-The tests use mock objects so they do not require heavy dependencies such as
-`ffmpeg` or `whisperx` to be installed.
+To focus on the API endpoints verified in `tests/test_api.py` you can run:
+
+```bash
+pytest tests/test_api.py
+```
+
+These tests rely on lightweight stubs, so they execute quickly without
+installing heavy runtime dependencies like `ffmpeg` or `whisperx`.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+import sys
+import types
+
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+from api import app, RUNS
+
+
+def test_run_status_review_flow(tmp_path, monkeypatch):
+    # Provide a lightweight experiment module used by the API
+    class DummyExp:
+        def __init__(self, config):
+            self.run_id = config["run_id"]
+            self.run_dir = Path(config["output_root"]) / self.run_id
+            self.log_file = self.run_dir / "run.log"
+
+    fake_module = types.ModuleType("experiment")
+    fake_module.SubtitleExperiment = DummyExp
+    monkeypatch.setitem(sys.modules, "experiment", fake_module)
+
+    def fake_execute(exp, run_id):
+        exp.run_dir.mkdir(parents=True, exist_ok=True)
+        exp.log_file.write_text("done", encoding="utf-8")
+        (exp.run_dir / "out.srt").write_text(
+            "1\n00:00:00,000 --> 00:00:01,000\nhello\n",
+            encoding="utf-8",
+        )
+        RUNS[run_id]["status"] = "completed"
+
+    monkeypatch.setattr("api._execute", fake_execute)
+
+    client = TestClient(app)
+    headers_admin = {"Authorization": "Bearer test-token"}
+    headers_viewer = {"Authorization": "Bearer viewer-token"}
+
+    config = {"run_id": "r1", "output_root": str(tmp_path)}
+    resp = client.post("/run", json=config, headers=headers_admin)
+    assert resp.status_code == 200
+    run_id = resp.json()["run_id"]
+
+    resp = client.get(f"/status/{run_id}", headers=headers_viewer)
+    assert resp.status_code == 200
+    status = resp.json()
+    assert status["status"] == "completed"
+    assert "done" in status["log"]
+
+    resp = client.get(f"/review/{run_id}", headers=headers_viewer)
+    assert resp.status_code == 200
+    review = resp.json()
+    assert "out.srt" in review["subtitles"]
+    assert "hello" in review["subtitles"]["out.srt"]
+
+    RUNS.clear()

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -25,10 +25,10 @@ def test_compress_old_runs(tmp_path):
     run_dir.mkdir(parents=True)
     (run_dir / "out.srt").write_text("data", encoding="utf-8")
     (run_dir / "audio.wav").write_text("raw", encoding="utf-8")
+    prune_raw_intermediates(str(runs), patterns=["*.wav"], dry_run=False)
     old_time = time.time() - 40 * 86400
     os.utime(run_dir, (old_time, old_time))
 
-    prune_raw_intermediates(str(runs), patterns=["*.wav"], dry_run=False)
     count = compress_old_runs(str(runs), days=30, dry_run=False)
     assert count == 1
     archive = runs / "r1.tar.gz"
@@ -37,3 +37,20 @@ def test_compress_old_runs(tmp_path):
     with tarfile.open(archive) as tar:
         names = tar.getnames()
     assert "audio.wav" not in names
+
+def test_prune_dry_run_keeps_files(tmp_path):
+    runs = tmp_path / "runs"
+    run_dir = runs / "r1"
+    run_dir.mkdir(parents=True)
+    target = run_dir / "audio.wav"
+    target.write_text("data", encoding="utf-8")
+
+    removed = prune_raw_intermediates(str(runs), patterns=["*.wav"], dry_run=True)
+    assert removed == 1
+    assert target.exists()
+
+
+def test_compress_missing_root(tmp_path):
+    missing = tmp_path / "none"
+    count = compress_old_runs(str(missing), days=30, dry_run=False)
+    assert count == 0


### PR DESCRIPTION
## Summary
- add FastAPI integration test covering /run, /status and /review
- expand maintenance cleanup tests and adjust timestamp handling
- run pytest in GitHub Actions and document local test execution

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689596c6f7a083338dd7dfdcd5de0db5