### PR TITLE
Add deployment and review workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,8 @@ BashOperator(
 - Integrate speaker diarization for multi‑speaker videos
 - Generate word‑level timestamps or translation
 - Parallelise processing across multiple GPUs
+- [Deployment guide](docs/deployment.md) for API, Docker, Airflow and authentication setup
+- [Review workflow](docs/review_workflow.md) describing human-in-the-loop corrections
 
 ## Troubleshooting Tips
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,43 @@
+# Deployment Guide
+
+This guide outlines the main deployment options for `subwhisper`, covering the API server, Docker usage, Airflow integration, and authentication.
+
+## FastAPI Service
+
+Run the transcription API locally with Uvicorn:
+
+```bash
+uvicorn api:app --host 0.0.0.0 --port 8000
+```
+
+The service exposes endpoints for starting runs, checking status, and submitting subtitle reviews.
+
+## Authentication Setup
+
+Endpoints are protected with bearer tokens defined in `auth.yaml` next to `api.py`:
+
+```yaml
+tokens:
+  my-admin-token: admin
+  read-only-token: viewer
+```
+
+Provide the token in requests using an `Authorization: Bearer <token>` header. Restart the server after editing the file to apply changes.
+
+## Docker
+
+Build and run the service in a container:
+
+```bash
+docker build -t subwhisper .
+docker run -p 8000:8000 \
+    -v "$(pwd)/input:/data/input" \
+    -v "$(pwd)/output:/data/output" \
+    subwhisper
+```
+
+For multi-container setups use `docker-compose up --build`.
+
+## Airflow
+
+The repository ships with an example DAG at `airflow/pipeline_dag.py`. Copy the file into your Airflow instance's `dags/` directory and ensure required dependencies from `requirements.txt` are installed. Trigger the DAG with configuration matching the `SubtitleExperiment` parameters to automate transcription jobs.

--- a/docs/review_workflow.md
+++ b/docs/review_workflow.md
@@ -1,0 +1,38 @@
+# Review Workflow
+
+Human review can improve subtitle accuracy. This guide shows how to fetch generated subtitles, apply corrections, and submit the results back to the service.
+
+## Retrieve Subtitles
+
+1. Identify the `run_id` of the transcription job.
+2. Request the files and current metadata:
+
+```bash
+curl -H "Authorization: Bearer <token>" \
+  http://localhost:8000/review/<run_id>
+```
+
+The response contains a mapping of subtitle filenames to their contents.
+
+## Apply Corrections
+
+Edit the subtitle text in your editor or load a rules file with `corrections.py`:
+
+```python
+from corrections import load_corrections, apply_corrections
+rules = load_corrections(Path("rules.yml"))
+new_text = apply_corrections(old_text, rules)
+```
+
+## Submit the Review
+
+Send the corrected text back to the API with reviewer information:
+
+```bash
+curl -X POST -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"corrections": {"teh": "the"}, "reviewer": {"name": "Bob"}}' \
+  http://localhost:8000/review/<run_id>
+```
+
+Corrections are merged into the existing subtitles and logged to `review_log.jsonl` for auditing.


### PR DESCRIPTION
## Summary
- document FastAPI, Docker, Airflow, and token auth setup in a new deployment guide
- describe the human-in-the-loop subtitle review process
- link new guides from the README enhancements section

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895991ee55c83339b42b7dba9b07d0a