### PR TITLE
Fix WhisperX load_model batch_size usage

### DIFF
--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -43,11 +43,10 @@ def test_forwards_options(tmp_path):
             }
             return {"segments": [{"start": 0.0, "end": 1.0, "text": "Hello"}]}
 
-    def load_model(model, language, compute_type, batch_size):
+    def load_model(model, language, compute_type):
         calls["load_model"] = {
             "language": language,
             "compute_type": compute_type,
-            "batch_size": batch_size,
         }
         return DummyModel()
 
@@ -81,7 +80,6 @@ def test_forwards_options(tmp_path):
     assert calls["load_model"] == {
         "language": "en",
         "compute_type": "float16",
-        "batch_size": 4,
     }
     assert calls["transcribe"] == {
         "batch_size": 4,

--- a/transcribe.py
+++ b/transcribe.py
@@ -1,3 +1,9 @@
+# Summary of changes
+# ------------------
+# - Removed unsupported ``batch_size`` argument from ``whisperx.load_model`` to
+#   avoid ``TypeError`` with newer WhisperX versions. ``batch_size`` is now only
+#   passed to ``transcribe`` and ``align``.
+
 """Utilities for transcribing audio with WhisperX and word-level alignment.
 
 The script expects the mono 16 kHz WAV produced by ``preproc.py`` and,
@@ -104,8 +110,10 @@ def transcribe_and_align(
         Path to the JSON file containing aligned segments.
     """
     asr_model = whisperx.load_model(
-        model, language="en", compute_type=compute_type, batch_size=batch_size
+        model, language="en", compute_type=compute_type
     )
+    # NOTE: ``batch_size`` is not accepted by ``whisperx.load_model`` in current
+    # versions. Specify ``batch_size`` only in ``transcribe`` and ``align`` calls.
 
     audio = whisperx.load_audio(audio_path)
     try:


### PR DESCRIPTION
## Summary
- avoid TypeError by dropping unsupported `batch_size` from `whisperx.load_model`
- clarify WhisperX options in tests

## Testing
- `PYTHONPATH=. pytest tests/test_transcribe.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895d3217d0c8333b293f76e33db7f1b