### PR TITLE
docs: document device selection

### DIFF
--- a/Getting_Started_Guide.md
+++ b/Getting_Started_Guide.md
@@ -58,10 +58,11 @@ The environment installs Python, FFmpeg, WhisperX, and other required packages
 
 ## 3. Transcribe the Audio
 
-1. Feed the cleaned audio into WhisperX:
+1. Feed the cleaned audio into WhisperX (use `--device cuda` for a GPU or
+   `--device cpu` if no GPU is available):
 
    ```bash
-   python transcribe.py preproc/normalized.wav --outdir transcript --music-segments preproc/music_segments.json
+   python transcribe.py preproc/normalized.wav --outdir transcript --music-segments preproc/music_segments.json --device cuda
    ```
 
 2. Results:
@@ -75,7 +76,7 @@ For reference, the complete Phase 1→2 pipeline looks like this:
 python preproc.py --input video.mp4 --denoise --normalize --outdir preproc
 
 # Phase 2: transcribe and align
-python transcribe.py preproc/normalized.wav --outdir transcript --music-segments preproc/music_segments.json
+python transcribe.py preproc/normalized.wav --outdir transcript --music-segments preproc/music_segments.json --device cuda
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ segments using WhisperX.
 
 ```bash
 python transcribe.py preproc/normalized.wav --outdir transcript \
-    --music-segments preproc/music_segments.json
+    --music-segments preproc/music_segments.json \
+    --device cuda
 ```
 
 #### Options
@@ -198,6 +199,8 @@ python transcribe.py preproc/normalized.wav --outdir transcript \
 - `--beam-size N` – beam search width used during decoding (default `5`).
 - `--compute-type TYPE` – precision for WhisperX such as `float16` or
   `float32` (default `float32`).
+- `--device DEVICE` – torch device to run on; defaults to `cuda` when a GPU
+  is available, otherwise `cpu`.
 - `--music-segments FILE` – optional JSON file with `[start, end]` pairs from
   Phase 1 to flag music regions.
 
@@ -229,7 +232,8 @@ python preproc.py --input video.mp4 --denoise --normalize --outdir preproc
 
 # Phase 2: transcribe and align using the cleaned audio and music ranges
 python transcribe.py preproc/normalized.wav --outdir transcript \
-    --music-segments preproc/music_segments.json
+    --music-segments preproc/music_segments.json \
+    --device cuda
 ```
 
 ## Phase-4: Validation & Benchmarking


### PR DESCRIPTION
## Summary
- mention `--device cuda` in Getting Started transcribe examples
- add `--device` flag to README CLI snippets and options

## Testing
- `pytest` *(fails: No module named 'fastapi', 'pysubs2', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6895e12af0e08333864a6e9e0a36c999