### PR TITLE
test: ensure transcribe handles models without beam size

### DIFF
--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -256,8 +256,12 @@ def test_transcribe_without_beam_size(tmp_path, caplog):
     stub.align = lambda segs, align_model, metadata, audio, batch_size: {"segments": segs}
 
     with caplog.at_level("INFO"):
-        transcribe.transcribe_and_align("dummy.wav", str(tmp_path), beam_size=2)
+        outpath = transcribe.transcribe_and_align("dummy.wav", str(tmp_path), beam_size=2)
 
+    assert outpath == str(tmp_path / "segments.json")
     assert calls["transcribe"] == {"batch_size": 8, "language": "en"}
+    assert json.loads(tmp_path.joinpath("segments.json").read_text()) == [
+        {"start": 0.0, "end": 1.0, "text": "Hello", "words": []}
+    ]
     assert "beam_size" in caplog.text
 


### PR DESCRIPTION
## Summary
- verify transcribe_and_align works with ASR models lacking a beam_size parameter
- check returned path and written segments for correctness

## Testing
- `pytest tests/test_transcribe.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895e7a4e7188333b72168928c8e057a