### PR TITLE
Ensure alignment model uses specified device

### DIFF
--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -64,10 +64,11 @@ def test_forwards_options(tmp_path):
         }
         return DummyModel()
 
-    def load_align_model(model_name, language_code):
+    def load_align_model(model_name, language_code, device):
         calls["load_align_model"] = {
             "model_name": model_name,
             "language_code": language_code,
+            "device": device,
         }
         return ("align", "meta")
 
@@ -105,6 +106,7 @@ def test_forwards_options(tmp_path):
     assert calls["load_align_model"] == {
         "model_name": transcribe.ALIGN_MODEL_NAME,
         "language_code": "en",
+        "device": expected_device,
     }
     assert calls["align"] == {"batch_size": 4}
     assert json.loads(tmp_path.joinpath("segments.json").read_text())[0]["words"][0]["word"] == "Hello"

--- a/transcribe.py
+++ b/transcribe.py
@@ -145,7 +145,7 @@ def transcribe_and_align(
 
     logger.info("Alignment model: %s", ALIGN_MODEL_NAME)
     align_model, metadata = whisperx.load_align_model(
-        model_name=ALIGN_MODEL_NAME, language_code="en"
+        model_name=ALIGN_MODEL_NAME, language_code="en", device=device
     )
 
     segments = result["segments"]


### PR DESCRIPTION
## Summary
- pass the current device when loading the WhisperX alignment model
- verify the device is forwarded to the alignment model in tests

## Testing
- `pip install pysubs2`
- `pytest tests/test_transcribe.py`


------
https://chatgpt.com/codex/tasks/task_e_6895fab230a0833380af16618720b155