### PR TITLE
Document required torch and pyannote versions

### DIFF
--- a/Getting_Started_Guide.md
+++ b/Getting_Started_Guide.md
@@ -37,7 +37,10 @@ Follow these simple steps to make subtitles for your videos.
    conda activate subwhisper
    ```
 
-The environment installs Python, FFmpeg, WhisperX, and other required packages
+The environment installs Python, FFmpeg, WhisperX, and other required packages.
+It also pins `torch` and `pyannote.audio` to versions compatible with the
+pretrained Pyannote VAD model (`torch==1.13.1`, `pyannote.audio==2.1.1`). Using
+different versions may lead to runtime warnings or failures.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ upgrade to a release that implements it or run VAD separately with
 `whisperx.load_vad_model` / `whisperx.detect_voice_activity` before
 transcription.
 
+### Version compatibility
+
+Pretrained Pyannote VAD models are sensitive to dependency versions. Use the
+exact pins from `requirements.txt` (or `environment.yml`) to avoid runtime
+warnings or failures:
+
+```bash
+pip install -r requirements.txt
+# or
+conda env create -f environment.yml
+```
+
+These files ensure that `torch==1.13.1` and `pyannote.audio==2.1.1` are
+installed.
+
 ### Required Software
 
 - **Python**: 3.9 or newer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 ctranslate2>=4.3
-torch==1.13.1  # required for pretrained Pyannote models
-pyannote.audio==2.1.1  # required for pretrained Pyannote models
+# pin torch and pyannote.audio to versions compatible with the pretrained
+# Pyannote VAD model; mismatched versions can raise runtime warnings or fail
+torch==1.13.1  # required for pretrained Pyannote VAD models
+pyannote.audio==2.1.1  # required for pretrained Pyannote VAD models
 pysubs2>=1.8.0
 speechbrain>=1.0
 whisperx>=3.4.2,<4  # use latest WhisperX


### PR DESCRIPTION
## Summary
- explain required dependency pins for torch and pyannote.audio in requirements
- note VAD model version compatibility in README and getting started guide

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68960108ae688333bc580b3e20816ccf