### PR TITLE
Refactor subtitle timing and wrapping

### DIFF
--- a/tests/test_enforce_limits.py
+++ b/tests/test_enforce_limits.py
@@ -16,21 +16,33 @@ def make_event(start, end, text):
 
 def test_wrap_and_truncate_lines():
     subs = pysubs2.SSAFile()
-    subs.events.append(make_event(0, 1000, "hello world it's me"))
+    subs.events.append(make_event(0, 2000, "hello world it's me"))
     enforce_limits(subs, max_chars=5, max_lines=2, max_duration=10.0, min_gap=0.0)
+    assert len(subs.events) == 1
     assert subs.events[0].text == "hello\\Nworld"
+    assert hasattr(subs.events[0], "event_cps")
 
 
-def test_clip_duration():
+def test_split_long_duration():
     subs = pysubs2.SSAFile()
-    subs.events.append(make_event(0, 7000, "long"))
+    subs.events.append(make_event(0, 7000, "hi"))
     enforce_limits(subs, max_chars=20, max_lines=1, max_duration=2.0, min_gap=0.0)
-    assert subs.events[0].end == 2000
+    assert all((ev.end - ev.start) <= 2000 for ev in subs.events)
 
 
-def test_insert_gap():
+def test_gap_shift_preserves_duration():
     subs = pysubs2.SSAFile()
     subs.events.append(make_event(0, 1000, "first"))
-    subs.events.append(make_event(1100, 2000, "second"))
-    enforce_limits(subs, max_chars=20, max_lines=1, max_duration=5.0, min_gap=0.5)
-    assert subs.events[1].start == 1500
+    subs.events.append(make_event(1100, 1600, "second"))
+    enforce_limits(subs, max_chars=20, max_lines=1, max_duration=5.0, min_gap=1.0)
+    ev = subs.events[1]
+    assert ev.start == 2000
+    assert ev.end - ev.start == 500
+
+
+def test_split_high_cps():
+    subs = pysubs2.SSAFile()
+    subs.events.append(make_event(0, 1000, "a" * 40))
+    enforce_limits(subs, max_chars=40, max_lines=1, max_duration=5.0, min_gap=0.0)
+    assert len(subs.events) > 1
+    assert all(ev.event_cps <= 17 for ev in subs.events)

--- a/tests/test_subtitle_pipeline.py
+++ b/tests/test_subtitle_pipeline.py
@@ -34,7 +34,7 @@ def _write_segments(tmp_path, segments):
 
 
 def test_enforce_limits_line_split_and_duration(tmp_path):
-    segs = [{"start": 0.0, "end": 10.0, "text": "hello world it's me"}]
+    segs = [{"start": 0.0, "end": 2.0, "text": "hello world it's me"}]
     seg_path = _write_segments(tmp_path, segs)
     subs = load_segments(seg_path)
     enforce_limits(subs, max_chars=5, max_lines=2, max_duration=2.0, min_gap=0.0)
@@ -57,7 +57,7 @@ def test_apply_corrections(tmp_path):
 
 def test_pipeline_skips_music_and_enforces_limits(tmp_path):
     segments = [
-        {"start": 0.0, "end": 10.0, "text": "hello world it's me"},
+        {"start": 0.0, "end": 2.0, "text": "hello world it's me"},
         {"start": 2.2, "end": 4.0, "text": "teh cat"},
         {"start": 4.0, "end": 5.0, "text": "\u266a\u266a", "is_music": True},
     ]


### PR DESCRIPTION
## Summary
- shift and split cues to maintain gaps and limit CPS
- wrap subtitle text after timing fixes
- expand tests for duration, CPS and gap handling

## Testing
- `pytest` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68963b1e4bec833382b729b9e87ec40f