### PR TITLE
Align subtitle limit defaults across pipeline and experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ The CLI exposes a number of switches for customising behaviour:
 - `--output-format`: subtitle format (`srt` or `vtt`, default `srt`)
 - `--output-dir`: directory where subtitle files are written; relative paths
   under the input directory are preserved
-- `--max-line-width`: maximum characters per subtitle line (default: `42`)
+- `--max-line-width`: maximum characters per subtitle line (default: `45`)
 - `--max-lines`: maximum lines per subtitle (default: `2`)
 - `--case`: normalise subtitle text casing (`lower` or `upper`)
 - `--strip-punctuation`: remove punctuation from subtitle text

--- a/experiment.py
+++ b/experiment.py
@@ -192,13 +192,13 @@ class SubtitleExperiment:
                 )
 
                 subs = load_segments(Path(segments_path))
-                enforce_limits(
-                    subs,
-                    fmt_cfg.get("max_chars", 42),
-                    fmt_cfg.get("max_lines", 2),
-                    fmt_cfg.get("max_duration", 6.0),
-                    fmt_cfg.get("min_gap", 0.1),
-                )
+                limits = {
+                    "max_chars": fmt_cfg.get("max_chars", 45),
+                    "max_lines": fmt_cfg.get("max_lines", 2),
+                    "max_duration": fmt_cfg.get("max_duration", 6.0),
+                    "min_gap": fmt_cfg.get("min_gap", 0.15),
+                }
+                enforce_limits(subs, **limits)
 
                 if rules:
                     for ev in subs.events:

--- a/subtitle_pipeline.py
+++ b/subtitle_pipeline.py
@@ -220,7 +220,7 @@ def main() -> None:  # pragma: no cover - CLI entry point
     parser.add_argument(
         "--max-chars",
         type=int,
-        default=42,
+        default=45,
         help="Maximum characters per line",
     )
     parser.add_argument(
@@ -238,7 +238,7 @@ def main() -> None:  # pragma: no cover - CLI entry point
     parser.add_argument(
         "--min-gap",
         type=float,
-        default=0.0,
+        default=0.15,
         help="Minimum gap between events in seconds",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- bump subtitle default max chars to 45 and set min gap to 0.15s in CLI
- mirror formatting fallbacks in `SubtitleExperiment`
- document updated max-line-width default

## Testing
- `pytest tests/test_subtitle_pipeline.py::test_enforce_limits_line_split_and_duration -q`
- `pytest tests/test_experiment.py::test_run_logging_and_aggregation -q`
- `pytest -q` *(killed: process OOM)*

------
https://chatgpt.com/codex/tasks/task_e_689640f227588333911a3d82027761c8