### PR TITLE
Include pysubs2 dependency and document GPU Docker options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,11 @@ WORKDIR /app
 # Install system dependencies and Python requirements
 COPY requirements.txt ./
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ffmpeg \
+    && apt-get install -y --no-install-recommends \
+        ffmpeg \
+        espeak-ng \
+        libxml2 \
+        libxslt1.1 \
     && pip install --no-cache-dir -r requirements.txt \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -150,9 +150,18 @@ inside the container (e.g. `/data/input/video.mp4` and set `output_root` to
 
 ### CPU and GPU variants
 
-The provided `Dockerfile` installs the CPU build of PyTorch. To leverage GPU
-hardware, swap the base image for a CUDA-enabled PyTorch image and run the
-container with `--gpus all` or an equivalent Docker Compose configuration.
+The provided `Dockerfile` builds a CPU-only image that uses the CPU build of
+PyTorch. For GPU acceleration, replace the base image with a CUDA-enabled
+PyTorch image, then rebuild and run the container with access to your GPU:
+
+```bash
+docker build -t subwhisper-cuda .
+docker run --gpus all subwhisper-cuda
+```
+
+Using `--gpus all` enables Docker's GPU passthrough so the container can run
+CUDA workloads. A similar flag can be added to your Docker Compose
+configuration if preferred.
 
 ## Phase-1: Audio Preprocessing
 

--- a/environment.yml
+++ b/environment.yml
@@ -26,3 +26,4 @@ dependencies:
       - aeneas>=1.7.3
       - fastapi
       - uvicorn
+      - pysubs2>=1.8.0


### PR DESCRIPTION
## Summary
- add `pysubs2>=1.8.0` to conda environment
- install `espeak-ng`, `libxml2` and `libxslt1.1` in Docker image for QC sync
- clarify CPU-only Dockerfile and give CUDA run example (`--gpus all`)

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch==1.13.1` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68964bf9194883338b8ecedfe9b22f99