### PR TITLE
Add CPS metrics to QC tool

### DIFF
--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -43,6 +43,8 @@ def test_collect_metrics(tmp_path):
     assert metrics["subtitle_count"] == 2
     assert metrics["avg_duration"] == pytest.approx(1.5)
     assert metrics["avg_lines"] == pytest.approx(1.5)
+    assert metrics["avg_cps"] == pytest.approx(7.75)
+    assert metrics["pct_cps_gt_17"] == pytest.approx(0.0)
     assert metrics["warnings"] == []
 
 


### PR DESCRIPTION
## Summary
- compute characters-per-second for each subtitle event
- report average CPS and percent of cues exceeding 17 CPS
- test metrics and ensure they surface in JSON/CSV outputs

## Testing
- `pytest tests/test_qc.py -q`
- `python qc.py subtitles.srt --json /tmp/out.json --csv /tmp/out.csv`

------
https://chatgpt.com/codex/tasks/task_e_6896533587508333b5006115cb3d1eb7