### PR TITLE
Pass format defaults directly to enforce_limits

### DIFF
--- a/experiment.py
+++ b/experiment.py
@@ -192,13 +192,14 @@ class SubtitleExperiment:
                 )
 
                 subs = load_segments(Path(segments_path))
-                limits = {
-                    "max_chars": fmt_cfg.get("max_chars", 45),
-                    "max_lines": fmt_cfg.get("max_lines", 2),
-                    "max_duration": fmt_cfg.get("max_duration", 6.0),
-                    "min_gap": fmt_cfg.get("min_gap", 0.15),
+                fmt_limits = {
+                    "max_chars": 45,
+                    "max_lines": 2,
+                    "max_duration": 6.0,
+                    "min_gap": 0.15,
+                    **fmt_cfg,
                 }
-                enforce_limits(subs, **limits)
+                enforce_limits(subs, **fmt_limits)
 
                 if rules:
                     for ev in subs.events:

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -3,6 +3,7 @@ import json
 from pathlib import Path
 import sys
 import types
+from typing import Any, Dict
 import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -36,8 +37,10 @@ def test_run_logging_and_aggregation(tmp_path, monkeypatch):
     def fake_load_segments(path):
         return DummySubs()
 
-    def fake_enforce(subs, *args, **kwargs):
-        pass
+    called: Dict[str, Any] = {}
+
+    def fake_enforce(subs, **kwargs):
+        called.update(kwargs)
 
     def fake_write_outputs(subs, srt_path, _):
         Path(srt_path).write_text("dummy", encoding="utf-8")
@@ -66,6 +69,13 @@ def test_run_logging_and_aggregation(tmp_path, monkeypatch):
     assert not cfg_path.exists()
 
     exp.run()
+
+    assert called == {
+        "max_chars": 45,
+        "max_lines": 2,
+        "max_duration": 6.0,
+        "min_gap": 0.15,
+    }
 
     metrics_path = run_dir / f"metrics_{cfg['run_id']}.json"
     assert cfg_path.exists()
@@ -119,7 +129,7 @@ def test_failure_tracking_and_rerun(tmp_path, monkeypatch):
     def fake_load_segments(path):
         return DummySubs()
 
-    def fake_enforce(subs, *args, **kwargs):
+    def fake_enforce(subs, **kwargs):
         pass
 
     def fake_write_outputs(subs, srt_path, _):
@@ -187,7 +197,7 @@ def test_parameter_sweep_outputs_and_aggregation(tmp_path, monkeypatch):
     def fake_load_segments(path):
         return DummySubs()
 
-    def fake_enforce(subs, *args, **kwargs):
+    def fake_enforce(subs, **kwargs):
         pass
 
     def fake_write_outputs(subs, srt_path, _):


### PR DESCRIPTION
## Summary
- ensure SubtitleExperiment applies formatting defaults (45/2/6.0/0.15) and forwards them straight to `enforce_limits`
- verify default formatting parameters in experiment tests

## Testing
- `pytest` *(fails: Killed)*
- `pytest tests/test_experiment.py`

------
https://chatgpt.com/codex/tasks/task_e_68965498049c8333bb03644304dfc682