### PR TITLE
Add smoke test script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ separate voice‑activity detection (VAD) step if you need to trim silence.
 The goal is to provide an easily hackable starting point for automated
 subtitle workflows.
 
+## Smoke Test
+
+Run a quick end-to-end check on a single video with:
+
+```bash
+bash scripts/smoke_test.sh path/to/video.mkv
+```
+
+Intermediate artifacts are written to `preproc/` and `transcript/`, the final
+subtitles to `subtitles.srt`, and a QC summary to `qc/summary.json`.
+
 ## API Authentication
 
 The accompanying FastAPI server secures its endpoints with simple

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 path/to/video" >&2
+  exit 1
+fi
+
+VIDEO="$1"
+
+# Preprocess audio
+python preproc.py --input "$VIDEO"
+
+# Transcribe audio
+python transcribe.py preproc/audio.wav --outdir transcript --music-segments preproc/music_segments.json
+
+# Generate subtitles
+python subtitle_pipeline.py --segments transcript/segments.json --output subtitles.srt
+
+# Run quality control
+python qc.py subtitles.srt --audio preproc/audio.wav --json qc/summary.json
+
+echo "QC summary written to qc/summary.json"


### PR DESCRIPTION
## Summary
- add `scripts/smoke_test.sh` to exercise preprocessing, transcription, subtitle generation and QC steps in order
- document smoke test usage and output locations in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68965b6095908333a6a0aae00f459737