### PR TITLE
Add optional QC sync validation

### DIFF
--- a/experiment.py
+++ b/experiment.py
@@ -210,13 +210,17 @@ class SubtitleExperiment:
                 srt_path = work_dir / f"{src_path.stem}_{self.run_id}.srt"
                 write_outputs(subs, srt_path, None)
 
+                qc_cfg = self.config.get("qc", {})
                 metrics = qc.collect_metrics(str(srt_path))
                 ref_path = references.get(src_path.stem)
                 if ref_path:
                     metrics["wer"] = qc.compute_wer(str(srt_path), ref_path)
 
-                sync_metrics = qc.validate_sync(str(srt_path), audio_path)
-                metrics.update({f"sync_{k}": v for k, v in sync_metrics.items()})
+                if qc_cfg.get("sync", True):
+                    sync_metrics = qc.validate_sync(str(srt_path), audio_path)
+                    metrics.update({f"sync_{k}": v for k, v in sync_metrics.items()})
+                else:
+                    metrics["sync_skipped"] = True
                 metrics["file"] = str(src)
                 metrics["status"] = "success"
                 self.results.append(metrics)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -11,9 +11,13 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 sys.modules["whisperx"] = types.ModuleType("whisperx")
+sys.modules["torch"] = types.ModuleType("torch")
+sys.modules["noisereduce"] = types.ModuleType("noisereduce")
 from experiment import SubtitleExperiment
 import experiment_runner
 sys.modules.pop("whisperx", None)
+sys.modules.pop("torch", None)
+sys.modules.pop("noisereduce", None)
 sys.modules.pop("transcribe", None)
 
 
@@ -105,6 +109,55 @@ def test_run_logging_and_aggregation(tmp_path, monkeypatch):
     assert "Best Parameter Sets" in summary_md.read_text()
 
     exp_csv.unlink()
+
+
+def test_skip_sync_validation(tmp_path, monkeypatch):
+    cfg = {
+        "run_id": "nosync",
+        "inputs": ["audio.wav"],
+        "output_root": str(tmp_path),
+        "qc": {"sync": False},
+    }
+
+    def fake_preprocess(src, workdir, **kwargs):
+        return src, []
+
+    def fake_transcribe(audio_path, out_dir, **kwargs):
+        return str(tmp_path / "segments.json")
+
+    class DummySubs:
+        def __init__(self):
+            self.events = []
+
+    def fake_load_segments(path):
+        return DummySubs()
+
+    def fake_enforce(subs, **kwargs):
+        pass
+
+    def fake_write_outputs(subs, srt_path, _):
+        Path(srt_path).write_text("dummy", encoding="utf-8")
+
+    def fake_collect_metrics(path):
+        return {}
+
+    def boom_validate_sync(path, audio):
+        raise AssertionError("should not run")
+
+    monkeypatch.setattr("experiment.preprocess_pipeline", fake_preprocess)
+    monkeypatch.setattr("experiment.transcribe_and_align", fake_transcribe)
+    monkeypatch.setattr("experiment.load_segments", fake_load_segments)
+    monkeypatch.setattr("experiment.enforce_limits", fake_enforce)
+    monkeypatch.setattr("experiment.write_outputs", fake_write_outputs)
+    monkeypatch.setattr("experiment.qc.collect_metrics", fake_collect_metrics)
+    monkeypatch.setattr("experiment.qc.validate_sync", boom_validate_sync)
+
+    exp = SubtitleExperiment(cfg)
+    exp.run()
+
+    metrics_path = Path(cfg["output_root"]) / cfg["run_id"] / f"metrics_{cfg['run_id']}.json"
+    metrics = json.loads(metrics_path.read_text())
+    assert metrics[0]["sync_skipped"] is True
 
 
 def test_failure_tracking_and_rerun(tmp_path, monkeypatch):

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -8,8 +8,14 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
-
+sys.modules["whisperx"] = types.ModuleType("whisperx")
+sys.modules["torch"] = types.ModuleType("torch")
+sys.modules["noisereduce"] = types.ModuleType("noisereduce")
 from experiment import SubtitleExperiment
+sys.modules.pop("whisperx", None)
+sys.modules.pop("torch", None)
+sys.modules.pop("noisereduce", None)
+sys.modules.pop("transcribe", None)
 
 
 def _setup_pipeline(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- allow disabling QC sync validation via `qc.sync` in config
- mark metrics when sync validation is skipped
- add test covering the skipped sync path and stub heavy deps in tests

## Testing
- `pytest tests/test_experiment.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6896ecf9c2048333a222f175ddec2b93