### PR TITLE
docs: update default Whisper model

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ python transcribe.py preproc/normalized.wav --outdir transcript \
   `preproc/normalized.wav`).
 - `--outdir DIR` – directory where `transcript.json` and `segments.json` are
   written.
-- `--model NAME` – Whisper model to load (default `large-v2`).
+- `--model NAME` – Whisper model to load (default `large-v3-turbo`).
 - `--batch-size N` – batch size for both transcription and alignment
   (default `8`).
 - `--beam-size N` – beam search width used during decoding (default `5`).


### PR DESCRIPTION
## Summary
- fix Phase 2 docs to note `large-v3-turbo` as the default Whisper model
- confirm smoke test script is referenced correctly

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6896f8195fe083339a58fb51709029b7