### PR TITLE
Clarify subtitle readability defaults

### DIFF
--- a/subtitle_pipeline.py
+++ b/subtitle_pipeline.py
@@ -15,6 +15,11 @@ from corrections import apply_corrections, load_corrections
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_MAX_CHARS = 45
+DEFAULT_MAX_LINES = 2
+DEFAULT_MAX_DURATION = 6.0
+DEFAULT_MIN_GAP = 0.15
+
 
 def load_segments(path: Path) -> pysubs2.SSAFile:
     """Load segments from a Whisper JSON output.
@@ -232,25 +237,25 @@ def main() -> None:  # pragma: no cover - CLI entry point
     parser.add_argument(
         "--max-chars",
         type=int,
-        default=45,
+        default=DEFAULT_MAX_CHARS,
         help="Maximum characters per line",
     )
     parser.add_argument(
         "--max-lines",
         type=int,
-        default=2,
+        default=DEFAULT_MAX_LINES,
         help="Maximum number of lines per event",
     )
     parser.add_argument(
         "--max-duration",
         type=float,
-        default=6.0,
+        default=DEFAULT_MAX_DURATION,
         help="Maximum duration for an event in seconds",
     )
     parser.add_argument(
         "--min-gap",
         type=float,
-        default=0.15,
+        default=DEFAULT_MIN_GAP,
         help="Minimum gap between events in seconds",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- define subtitle formatting defaults as constants
- use constants for `subtitle_pipeline` CLI arguments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `python subtitle_pipeline.py --help` *(fails: ModuleNotFoundError: No module named 'pysubs2')*

------
https://chatgpt.com/codex/tasks/task_e_6896fd77e13483338b44cea2974da977