### PR TITLE
feat: add skip music flag

### DIFF
--- a/transcribe.py
+++ b/transcribe.py
@@ -259,6 +259,11 @@ def main() -> None:
         help="JSON file containing a list of [start, end] music ranges",
     )
     parser.add_argument(
+        "--skip-music",
+        action="store_true",
+        help="Drop segments overlapping music ranges",
+    )
+    parser.add_argument(
         "--spellcheck",
         action="store_true",
         help="Run LanguageTool spell check on output (slow; requires Java)",
@@ -289,6 +294,7 @@ def main() -> None:
         batch_size=args.batch_size,
         beam_size=args.beam_size,
         music_segments=music_ranges,
+        skip_music=args.skip_music,
         spellcheck=args.spellcheck,
     )
     logger.info("JSON output written to %s", outpath)


### PR DESCRIPTION
## Summary
- add `--skip-music` CLI flag to drop music-overlapping segments
- forward `skip_music` option to `transcribe_and_align`

## Testing
- `python transcribe.py --help`
- `python - <<'PY' ...` (stubbed run with `--skip-music`) 
- `pytest -q` *(fails: No module named 'fastapi', 'librosa', 'jiwer')*


------
https://chatgpt.com/codex/tasks/task_e_68970581093083338620601b4abde9a9