### PR TITLE
Handle missing aeneas in sync validation

### DIFF
--- a/experiment.py
+++ b/experiment.py
@@ -217,8 +217,12 @@ class SubtitleExperiment:
                     metrics["wer"] = qc.compute_wer(str(srt_path), ref_path)
 
                 if qc_cfg.get("sync", True):
-                    sync_metrics = qc.validate_sync(str(srt_path), audio_path)
-                    metrics.update({f"sync_{k}": v for k, v in sync_metrics.items()})
+                    try:
+                        sync_metrics = qc.validate_sync(str(srt_path), audio_path)
+                    except ImportError:
+                        metrics["sync_skipped"] = True
+                    else:
+                        metrics.update({f"sync_{k}": v for k, v in sync_metrics.items()})
                 else:
                     metrics["sync_skipped"] = True
                 metrics["file"] = str(src)

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -13,11 +13,19 @@ if str(ROOT) not in sys.path:
 sys.modules["whisperx"] = types.ModuleType("whisperx")
 sys.modules["torch"] = types.ModuleType("torch")
 sys.modules["noisereduce"] = types.ModuleType("noisereduce")
+sys.modules["librosa"] = types.ModuleType("librosa")
+sys.modules["soundfile"] = types.ModuleType("soundfile")
+sys.modules["jiwer"] = types.ModuleType("jiwer")
+sys.modules["pysubs2"] = types.ModuleType("pysubs2")
 from experiment import SubtitleExperiment
 import experiment_runner
 sys.modules.pop("whisperx", None)
 sys.modules.pop("torch", None)
 sys.modules.pop("noisereduce", None)
+sys.modules.pop("librosa", None)
+sys.modules.pop("soundfile", None)
+sys.modules.pop("jiwer", None)
+sys.modules.pop("pysubs2", None)
 sys.modules.pop("transcribe", None)
 
 
@@ -151,6 +159,54 @@ def test_skip_sync_validation(tmp_path, monkeypatch):
     monkeypatch.setattr("experiment.write_outputs", fake_write_outputs)
     monkeypatch.setattr("experiment.qc.collect_metrics", fake_collect_metrics)
     monkeypatch.setattr("experiment.qc.validate_sync", boom_validate_sync)
+
+    exp = SubtitleExperiment(cfg)
+    exp.run()
+
+    metrics_path = Path(cfg["output_root"]) / cfg["run_id"] / f"metrics_{cfg['run_id']}.json"
+    metrics = json.loads(metrics_path.read_text())
+    assert metrics[0]["sync_skipped"] is True
+
+
+def test_sync_validation_import_error(tmp_path, monkeypatch):
+    cfg = {
+        "run_id": "nosyncimp",
+        "inputs": ["audio.wav"],
+        "output_root": str(tmp_path),
+    }
+
+    def fake_preprocess(src, workdir, **kwargs):
+        return src, []
+
+    def fake_transcribe(audio_path, out_dir, **kwargs):
+        return str(tmp_path / "segments.json")
+
+    class DummySubs:
+        def __init__(self):
+            self.events = []
+
+    def fake_load_segments(path):
+        return DummySubs()
+
+    def fake_enforce(subs, **kwargs):
+        pass
+
+    def fake_write_outputs(subs, srt_path, _):
+        Path(srt_path).write_text("dummy", encoding="utf-8")
+
+    def fake_collect_metrics(path):
+        return {}
+
+    def import_error_validate_sync(path, audio):
+        raise ImportError("no aeneas")
+
+    monkeypatch.setattr("experiment.preprocess_pipeline", fake_preprocess)
+    monkeypatch.setattr("experiment.transcribe_and_align", fake_transcribe)
+    monkeypatch.setattr("experiment.load_segments", fake_load_segments)
+    monkeypatch.setattr("experiment.enforce_limits", fake_enforce)
+    monkeypatch.setattr("experiment.write_outputs", fake_write_outputs)
+    monkeypatch.setattr("experiment.qc.collect_metrics", fake_collect_metrics)
+    monkeypatch.setattr("experiment.qc.validate_sync", import_error_validate_sync)
 
     exp = SubtitleExperiment(cfg)
     exp.run()


### PR DESCRIPTION
## Summary
- Gracefully handle ImportError when validating sync by skipping and recording `sync_skipped`
- Add tests for import-error scenario and stub optional dependencies

## Testing
- `pytest tests/test_experiment.py::test_skip_sync_validation tests/test_experiment.py::test_sync_validation_import_error -q`


------
https://chatgpt.com/codex/tasks/task_e_689707b4356c83338b4fcfdb5bbedc3e