### PR TITLE
Pass stem to preprocess in CLI

### DIFF
--- a/subwhisper_cli.py
+++ b/subwhisper_cli.py
@@ -56,6 +56,7 @@ def _process_one(
         denoise_aggressiveness=0.85,
         normalize=True,
         music_threshold=0.5,
+        stem=media.stem,
     )
 
     # 2) Transcribe+align → write <stem>.transcript.json & <stem>.segments.json in work


### PR DESCRIPTION
## Summary
- forward media stem to preprocess step so intermediate files are stemmed

## Testing
- `pytest tests/test_preproc.py::test_preprocess_pipeline_stem_builds_filenames -q`


------
https://chatgpt.com/codex/tasks/task_e_68976f7830a08333a890916f8373a787