### PR TITLE
Gate cleanup on success flag in CLI

### DIFF
--- a/subwhisper_cli.py
+++ b/subwhisper_cli.py
@@ -98,23 +98,25 @@ def _process_one(
     write_outputs(subs, out_srt, out_txt_path)
 
     # Mark success
-    (work / "SUCCESS").write_text("ok", encoding="utf-8")
+    success_flag = work / "SUCCESS"
+    success_flag.write_text("ok", encoding="utf-8")
 
-    # Cleanup policy
-    if purge_all_on_success:
-        try:
-            out_srt.unlink(missing_ok=True)
-            if out_txt_path:
-                out_txt_path.unlink(missing_ok=True)
-        except Exception:
-            pass
-    if clean_intermediates:
-        # delete the work dir tree
-        import shutil
-        try:
-            shutil.rmtree(work)
-        except Exception:
-            pass
+    # Cleanup policy: only run when success flag exists
+    if success_flag.exists():
+        if purge_all_on_success:
+            try:
+                out_srt.unlink(missing_ok=True)
+                if out_txt_path:
+                    out_txt_path.unlink(missing_ok=True)
+            except Exception:
+                pass
+        if clean_intermediates:
+            # delete the work dir tree
+            import shutil
+            try:
+                shutil.rmtree(work)
+            except Exception:
+                pass
 
     return 0
 


### PR DESCRIPTION
## Summary
- ensure CLI cleanup only runs when success flag exists

## Testing
- `pytest` *(killed)*

------
https://chatgpt.com/codex/tasks/task_e_68977090555883339a201d05c6bf1848