### PR TITLE
Create per-media output directories in CLI

### DIFF
--- a/subwhisper_cli.py
+++ b/subwhisper_cli.py
@@ -14,7 +14,7 @@ from corrections import load_corrections, apply_corrections
 def _resolve_outputs(input_path: Path, output_root: Optional[Path]) -> Tuple[Path, Path, str]:
     stem = input_path.stem
     if output_root:
-        out_dir = output_root
+        out_dir = output_root / stem
     else:
         out_dir = input_path.parent
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_subwhisper_cli.py
+++ b/tests/test_subwhisper_cli.py
@@ -1,4 +1,30 @@
 from pathlib import Path
+import sys
+import types
+
+preproc_stub = types.ModuleType("preproc")
+preproc_stub.preprocess_pipeline = lambda *a, **k: None
+sys.modules.setdefault("preproc", preproc_stub)
+
+transcribe_stub = types.ModuleType("transcribe")
+transcribe_stub.transcribe_and_align = lambda *a, **k: None
+sys.modules.setdefault("transcribe", transcribe_stub)
+
+subtitle_stub = types.ModuleType("subtitle_pipeline")
+subtitle_stub.load_segments = lambda *a, **k: None
+subtitle_stub.enforce_limits = lambda *a, **k: None
+subtitle_stub.write_outputs = lambda *a, **k: None
+sys.modules.setdefault("subtitle_pipeline", subtitle_stub)
+
+corrections_stub = types.ModuleType("corrections")
+corrections_stub.load_corrections = lambda *a, **k: None
+corrections_stub.apply_corrections = lambda *a, **k: None
+sys.modules.setdefault("corrections", corrections_stub)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from subwhisper_cli import _resolve_outputs
+
 
 def test_no_sync_flag_absent():
     cli_path = Path(__file__).resolve().parents[1] / "subwhisper_cli.py"
@@ -6,3 +32,23 @@ def test_no_sync_flag_absent():
     assert "--no-sync" not in content
     assert "no_sync" not in content
     assert "--skip-music" in content
+
+
+def test_resolve_outputs_same_stem(tmp_path):
+    media1 = tmp_path / "dir1" / "foo.mp4"
+    media2 = tmp_path / "dir2" / "foo.mkv"
+    media1.parent.mkdir(parents=True)
+    media2.parent.mkdir(parents=True)
+    media1.touch()
+    media2.touch()
+
+    output_root = tmp_path / "out"
+    srt1, txt1, _ = _resolve_outputs(media1, output_root)
+    srt2, txt2, _ = _resolve_outputs(media2, output_root)
+
+    expected_dir = output_root / "foo"
+    assert srt1 == expected_dir / "foo.srt"
+    assert txt1 == expected_dir / "foo.txt"
+    assert srt2 == srt1
+    assert txt2 == txt1
+    assert expected_dir.is_dir()


### PR DESCRIPTION
## Summary
- ensure `_resolve_outputs` writes outputs into a stem-named subdirectory when an `output_root` is supplied
- regression test for resolving outputs when files share a stem in different folders

## Testing
- `pytest tests/test_subwhisper_cli.py::test_resolve_outputs_same_stem -q`
- `pytest tests/test_subwhisper_cli.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68977f369b588333b2afc8c1e8e87640