### PR TITLE
Add packaging metadata and CLI entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ separate voice‑activity detection (VAD) step if you need to trim silence.
 The goal is to provide an easily hackable starting point for automated
 subtitle workflows.
 
+## Installation
+
+Install the package from the repository root to expose the `subwhisper-cli`
+command:
+
+```bash
+pip install .
+# or, for development
+pip install -e .
+```
+
+Once installed, `subwhisper-cli` runs the end-to-end subtitle pipeline.
+
 ## Smoke Test
 
 Run a quick end-to-end check on a single video with:
@@ -26,7 +39,7 @@ subtitles to `subtitles.srt`, and a QC summary to `qc/summary.json`.
 ### One-shot command
 
 ```bash
-python subwhisper_cli.py --input /path/to/video.mkv --device cuda
+subwhisper-cli --input /path/to/video.mkv --device cuda
 ```
 
 - Default output is `/path/to/video.srt`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "subwhisper"
+version = "0.1.0"
+description = "Subtitle generation using WhisperX"
+readme = "README.md"
+requires-python = ">=3.9"
+license = {text = "MIT"}
+authors = [{name = "Subwhisper Contributors"}]
+dependencies = [
+    "ctranslate2>=4.3",
+    "torch==1.13.1",
+    "pyannote.audio==2.1.1",
+    "pysubs2>=1.8.0",
+    "speechbrain>=1.0",
+    "whisperx>=3.4.2,<4",
+    "librosa>=0.10",
+    "noisereduce>=3.0",
+    "packaging",
+    "rich",
+    "jiwer>=3.0",
+    "pyyaml",
+    "language_tool_python",
+    "aeneas>=1.7.3",
+    "fastapi",
+    "uvicorn",
+]
+
+[project.scripts]
+"subwhisper-cli" = "subwhisper_cli:main"


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with project metadata, dependencies, and `subwhisper-cli` console script
- document how to install the project and run `subwhisper-cli`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6897810f54008333afb94d7a1755c372