### PR TITLE
Refactor preprocessing and transcription outputs with resume support

### DIFF
--- a/experiment.py
+++ b/experiment.py
@@ -178,20 +178,25 @@ class SubtitleExperiment:
                 work_dir = self.run_dir / src_path.stem
                 work_dir.mkdir(parents=True, exist_ok=True)
 
-                audio_path, music_segments = preprocess_pipeline(
+                pre_out = preprocess_pipeline(
                     src, str(work_dir), **pre_cfg
                 )
+                audio_path = pre_out.get("normalized_wav") or pre_out.get("audio_wav")
+                music_segments = None
+                if pre_out.get("music_segments"):
+                    with open(pre_out["music_segments"], "r", encoding="utf-8") as fh:
+                        music_segments = json.load(fh)
 
                 trans_dir = work_dir / "transcript"
                 trans_dir.mkdir(exist_ok=True)
-                segments_path = transcribe_and_align(
+                trans_out = transcribe_and_align(
                     audio_path,
                     str(trans_dir),
                     music_segments=music_segments,
                     **tr_cfg,
                 )
 
-                subs = load_segments(Path(segments_path))
+                subs = load_segments(Path(trans_out["segments_json"]))
 
                 if rules:
                     for ev in subs.events:

--- a/subtitle_pipeline.py
+++ b/subtitle_pipeline.py
@@ -193,7 +193,7 @@ def spellcheck_lines(subs: pysubs2.SSAFile, lang: str = "en-US") -> pysubs2.SSAF
 
 def write_outputs(
     subs: pysubs2.SSAFile, out_srt: Path, out_txt: Optional[Path]
-) -> None:
+) -> dict:
     """Write subtitle collection to ``out_srt`` and optionally ``out_txt``.
 
     Parameters
@@ -205,12 +205,25 @@ def write_outputs(
     out_txt:
         Optional path where plain text lines are written, one per subtitle
         event. When ``None`` the text file is skipped.
+
+    Returns
+    -------
+    dict
+        Mapping with keys ``srt`` and ``txt`` pointing to written files. ``txt``
+        is ``None`` when ``out_txt`` is ``None``.
     """
 
+    out_srt.unlink(missing_ok=True)
     subs.save(out_srt, format_="srt")
+
+    txt_path = None
     if out_txt is not None:
+        out_txt.unlink(missing_ok=True)
         lines = [ev.plaintext for ev in subs.events]
         out_txt.write_text("\n".join(lines), encoding="utf-8")
+        txt_path = str(out_txt)
+
+    return {"srt": str(out_srt), "txt": txt_path}
 
 
 def main() -> None:  # pragma: no cover - CLI entry point

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -37,10 +37,13 @@ def test_run_logging_and_aggregation(tmp_path, monkeypatch):
     }
 
     def fake_preprocess(src, workdir, **kwargs):
-        return src, []
+        return {"audio_wav": src, "normalized_wav": None, "music_segments": None}
 
     def fake_transcribe(audio_path, out_dir, **kwargs):
-        return str(tmp_path / "segments.json")
+        return {
+            "segments_json": str(tmp_path / "segments.json"),
+            "transcript_json": str(tmp_path / "transcript.json"),
+        }
 
     class DummySubs:
         def __init__(self):
@@ -128,10 +131,13 @@ def test_skip_sync_validation(tmp_path, monkeypatch):
     }
 
     def fake_preprocess(src, workdir, **kwargs):
-        return src, []
+        return {"audio_wav": src, "normalized_wav": None, "music_segments": None}
 
     def fake_transcribe(audio_path, out_dir, **kwargs):
-        return str(tmp_path / "segments.json")
+        return {
+            "segments_json": str(tmp_path / "segments.json"),
+            "transcript_json": str(tmp_path / "transcript.json"),
+        }
 
     class DummySubs:
         def __init__(self):
@@ -176,10 +182,13 @@ def test_sync_validation_import_error(tmp_path, monkeypatch):
     }
 
     def fake_preprocess(src, workdir, **kwargs):
-        return src, []
+        return {"audio_wav": src, "normalized_wav": None, "music_segments": None}
 
     def fake_transcribe(audio_path, out_dir, **kwargs):
-        return str(tmp_path / "segments.json")
+        return {
+            "segments_json": str(tmp_path / "segments.json"),
+            "transcript_json": str(tmp_path / "transcript.json"),
+        }
 
     class DummySubs:
         def __init__(self):
@@ -224,12 +233,15 @@ def test_failure_tracking_and_rerun(tmp_path, monkeypatch):
     }
 
     def fake_preprocess(src, workdir, **kwargs):
-        return src, []
+        return {"audio_wav": src, "normalized_wav": None, "music_segments": None}
 
     def fake_transcribe(audio_path, out_dir, **kwargs):
         if Path(audio_path).name == "bad.wav":
             raise RuntimeError("boom")
-        return str(tmp_path / "segments.json")
+        return {
+            "segments_json": str(tmp_path / "segments.json"),
+            "transcript_json": str(tmp_path / "transcript.json"),
+        }
 
     class DummySubs:
         def __init__(self):
@@ -268,7 +280,10 @@ def test_failure_tracking_and_rerun(tmp_path, monkeypatch):
 
     # Patch to succeed on rerun
     def success_transcribe(audio_path, out_dir, **kwargs):
-        return str(tmp_path / "segments.json")
+        return {
+            "segments_json": str(tmp_path / "segments.json"),
+            "transcript_json": str(tmp_path / "transcript.json"),
+        }
 
     monkeypatch.setattr("experiment.transcribe_and_align", success_transcribe)
     from rerun_failed import main as rerun_main
@@ -294,10 +309,13 @@ def test_parameter_sweep_outputs_and_aggregation(tmp_path, monkeypatch):
     cfg_path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
 
     def fake_preprocess(src, workdir, **kwargs):
-        return src, []
+        return {"audio_wav": src, "normalized_wav": None, "music_segments": None}
 
     def fake_transcribe(audio_path, out_dir, **kwargs):
-        return str(tmp_path / "segments.json")
+        return {
+            "segments_json": str(tmp_path / "segments.json"),
+            "transcript_json": str(tmp_path / "transcript.json"),
+        }
 
     class DummySubs:
         def __init__(self):

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -22,10 +22,13 @@ def _setup_pipeline(monkeypatch, tmp_path: Path) -> None:
     """Stub heavy dependencies used by ``SubtitleExperiment``."""
 
     def fake_preprocess(src, workdir, **kwargs):
-        return src, []
+        return {"audio_wav": src, "normalized_wav": None, "music_segments": None}
 
     def fake_transcribe(audio_path, out_dir, **kwargs):
-        return str(tmp_path / "segments.json")
+        return {
+            "segments_json": str(tmp_path / "segments.json"),
+            "transcript_json": str(tmp_path / "transcript.json"),
+        }
 
     class DummySubs:
         def __init__(self):


### PR DESCRIPTION
## Summary
- Refactor `preprocess_pipeline` to return structured paths and support resume mode
- Enhance `transcribe_and_align` to emit both transcript and segment JSON paths and skip work when resuming
- Add overwrite-safe `write_outputs` returning written subtitle paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c83523e48333975aa9cd97f06fcb