### PR TITLE
Implement manifest-based resume and caching in CLI

### DIFF
--- a/subwhisper_cli.py
+++ b/subwhisper_cli.py
@@ -2,14 +2,27 @@ import argparse
 import sys
 import traceback
 import json
-from datetime import datetime
+import logging
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Set
 
 from preproc import preprocess_pipeline
 from transcribe import transcribe_and_align
 from subtitle_pipeline import load_segments, enforce_limits, write_outputs
 from corrections import load_corrections, apply_corrections
+from run_state import (
+    compute_source_fingerprint,
+    load_manifest,
+    stage_complete,
+    is_stage_reusable,
+    acquire_lock,
+    release_lock,
+    clean_old_manifests,
+    CACHE_DIR,
+    MANIFEST_SUFFIX,
+)
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_outputs(input_path: Path, output_root: Optional[Path]) -> Tuple[Path, Path, str]:
@@ -25,8 +38,8 @@ def _resolve_outputs(input_path: Path, output_root: Optional[Path]) -> Tuple[Pat
 
 
 def _work_dir_for(input_path: Path) -> Path:
-    ts = datetime.now().strftime("%Y%m%d-%H%M%S")
-    return input_path.parent / ".subwhisper_runs" / ts / input_path.stem
+    cache_root = input_path.parent / CACHE_DIR
+    return cache_root / input_path.stem
 
 
 def _process_one(
@@ -42,88 +55,185 @@ def _process_one(
     max_duration: float,
     min_gap: float,
     corrections_path: Optional[Path],
+    resume: str,
+    force: bool,
+    resume_clean_days: Optional[int],
+    cleaned_roots: Set[Path],
 ) -> int:
     work = _work_dir_for(media)
     work.mkdir(parents=True, exist_ok=True)
+    cache_root = work.parent
+    manifest_path = cache_root / f"{media.stem}{MANIFEST_SUFFIX}"
 
-    # 1) Preprocess → returns path to final audio and music segments
-    # We enable normalize by default; denoise optional (off by default here)
-    pre_out = preprocess_pipeline(
-        input_path=str(media),
-        outdir=str(work),
-        track_index=None,
-        denoise=False,
-        denoise_aggressiveness=0.85,
-        normalize=True,
-        music_threshold=0.5,
-        stem=media.stem,
-    )
-    audio_path = pre_out.get("normalized_wav") or pre_out.get("audio_wav")
-    music_segments = None
-    if pre_out.get("music_segments"):
-        with open(pre_out["music_segments"], "r", encoding="utf-8") as fh:
-            music_segments = json.load(fh)
+    if resume_clean_days and cache_root not in cleaned_roots:
+        removed = clean_old_manifests(cache_root, resume_clean_days)
+        if removed:
+            logger.info("resume: cleaned %s old manifests", removed)
+        cleaned_roots.add(cache_root)
 
-    # 2) Transcribe+align → write <stem>.transcript.json & <stem>.segments.json in work
-    stem = media.stem
-    trans_out = transcribe_and_align(
-        audio_path=audio_path,
-        outdir=str(work),
-        model="large-v3-turbo",
-        compute_type="float32",
-        device=device,
-        batch_size=8,
-        beam_size=5,
-        music_segments=music_segments,
-        skip_music=skip_music,
-        spellcheck=False,
-        stem=stem,  # added parameter supported by our transcribe.py change
-    )
+    acquire_lock(manifest_path)
+    try:
+        # Compute source fingerprint and load manifest
+        _ = compute_source_fingerprint(str(media))
+        manifest = load_manifest(media.parent, media.stem)
+        if force or resume == "off":
+            manifest = {}
 
-    # 3) Format → enforce limits and write SRT/TXT to output folder (default: media.parent)
-    out_srt, out_txt, stem = _resolve_outputs(media, output_root)
-    subs = load_segments(Path(trans_out["segments_json"]))
+        allow_resume = resume != "off" and not force
+        downstream_valid = True
 
-    # Apply corrections first if provided
-    if corrections_path and corrections_path.exists():
-        rules = load_corrections(corrections_path)
-        for ev in subs.events:
-            fixed = apply_corrections(ev.plaintext, rules)
-            ev.text = fixed.replace("\n", "\\N")
+        audio_path: Optional[str] = None
+        music_segments = None
 
-    # Enforce limits and write outputs
-    enforce_limits(
-        subs,
-        max_chars=max_chars,
-        max_lines=max_lines,
-        max_duration=max_duration,
-        min_gap=min_gap,
-    )
-    out_txt_path = out_txt if write_transcript_flag else None
-    write_outputs(subs, out_srt, out_txt_path)
+        # Stage: preprocess
+        preproc_params = {
+            "denoise": False,
+            "denoise_aggressiveness": 0.85,
+            "normalize": True,
+            "music_threshold": 0.5,
+        }
+        reusable, outputs = (
+            is_stage_reusable(media.parent, media.stem, "preproc", str(media), preproc_params)
+            if allow_resume and downstream_valid
+            else (False, [])
+        )
+        if reusable:
+            logger.info("resume: preproc valid; skipping")
+            audio_path = outputs[0]
+            if len(outputs) > 1:
+                try:
+                    with open(outputs[1], "r", encoding="utf-8") as fh:
+                        music_segments = json.load(fh)
+                except Exception:
+                    music_segments = None
+        else:
+            logger.info("resume: preproc invalid; running")
+            pre_out = preprocess_pipeline(
+                input_path=str(media),
+                outdir=str(work),
+                track_index=None,
+                denoise=False,
+                denoise_aggressiveness=0.85,
+                normalize=True,
+                music_threshold=0.5,
+                stem=media.stem,
+            )
+            audio_path = pre_out.get("normalized_wav") or pre_out.get("audio_wav")
+            outputs = [audio_path]
+            if pre_out.get("music_segments"):
+                with open(pre_out["music_segments"], "r", encoding="utf-8") as fh:
+                    music_segments = json.load(fh)
+                outputs.append(pre_out["music_segments"])
+            stage_complete(media.parent, media.stem, "preproc", str(media), preproc_params, outputs)
+        downstream_valid = downstream_valid and reusable
 
-    # Mark success
-    success_flag = work / "SUCCESS"
-    success_flag.write_text("ok", encoding="utf-8")
+        # Stage: transcribe
+        transcribe_params = {
+            "model": "large-v3-turbo",
+            "compute_type": "float32",
+            "device": device,
+            "batch_size": 8,
+            "beam_size": 5,
+            "skip_music": skip_music,
+        }
+        reusable, outputs = (
+            is_stage_reusable(media.parent, media.stem, "transcribe", str(media), transcribe_params)
+            if allow_resume and downstream_valid
+            else (False, [])
+        )
+        if reusable:
+            logger.info("resume: transcribe valid; skipping")
+            trans_out = {
+                "transcript_json": outputs[0],
+                "segments_json": outputs[1] if len(outputs) > 1 else None,
+            }
+        else:
+            logger.info("resume: transcribe invalid; running")
+            trans_out = transcribe_and_align(
+                audio_path=audio_path,
+                outdir=str(work),
+                model="large-v3-turbo",
+                compute_type="float32",
+                device=device,
+                batch_size=8,
+                beam_size=5,
+                music_segments=music_segments,
+                skip_music=skip_music,
+                spellcheck=False,
+                stem=media.stem,
+            )
+            outputs = [trans_out["transcript_json"], trans_out["segments_json"]]
+            stage_complete(media.parent, media.stem, "transcribe", str(media), transcribe_params, outputs)
+        downstream_valid = downstream_valid and reusable
 
-    # Cleanup policy: only run when success flag exists
-    if success_flag.exists():
-        if purge_all_on_success:
-            try:
-                out_srt.unlink(missing_ok=True)
-                if out_txt_path:
-                    out_txt_path.unlink(missing_ok=True)
-            except Exception:
-                pass
-        if clean_intermediates:
-            # delete the work dir tree
-            import shutil
-            try:
-                shutil.rmtree(work)
-            except Exception:
-                pass
+        # Stage: format
+        out_srt, out_txt, stem = _resolve_outputs(media, output_root)
+        out_txt_path = out_txt if write_transcript_flag else None
+        corrections_fp = (
+            compute_source_fingerprint(str(corrections_path))
+            if corrections_path and corrections_path.exists()
+            else None
+        )
+        format_params = {
+            "max_chars": max_chars,
+            "max_lines": max_lines,
+            "max_duration": max_duration,
+            "min_gap": min_gap,
+            "write_transcript": write_transcript_flag,
+            "output_root": str(output_root) if output_root else None,
+            "corrections": corrections_fp,
+        }
+        reusable, outputs = (
+            is_stage_reusable(media.parent, media.stem, "format", str(media), format_params)
+            if allow_resume and downstream_valid
+            else (False, [])
+        )
+        if reusable:
+            logger.info("resume: format valid; skipping")
+        else:
+            logger.info("resume: format invalid; running")
+            subs = load_segments(Path(trans_out["segments_json"]))
+            if corrections_path and corrections_path.exists():
+                rules = load_corrections(corrections_path)
+                for ev in subs.events:
+                    fixed = apply_corrections(ev.plaintext, rules)
+                    ev.text = fixed.replace("\n", "\\N")
+            enforce_limits(
+                subs,
+                max_chars=max_chars,
+                max_lines=max_lines,
+                max_duration=max_duration,
+                min_gap=min_gap,
+            )
+            write_outputs(subs, out_srt, out_txt_path)
+            outputs = [str(out_srt)]
+            if out_txt_path:
+                outputs.append(str(out_txt_path))
+            stage_complete(media.parent, media.stem, "format", str(media), format_params, outputs)
 
-    return 0
+        # Mark success
+        success_flag = work / "SUCCESS"
+        success_flag.write_text("ok", encoding="utf-8")
+
+        # Cleanup policy: only run when success flag exists
+        if success_flag.exists():
+            if purge_all_on_success:
+                try:
+                    out_srt.unlink(missing_ok=True)
+                    if out_txt_path:
+                        out_txt_path.unlink(missing_ok=True)
+                except Exception:
+                    pass
+            if clean_intermediates:
+                import shutil
+                try:
+                    shutil.rmtree(work)
+                except Exception:
+                    pass
+
+        return 0
+    finally:
+        release_lock(manifest_path)
 
 
 def main() -> int:
@@ -145,13 +255,20 @@ def main() -> int:
     p.add_argument("--max-duration", type=float, default=6.0)
     p.add_argument("--min-gap", type=float, default=0.15)
     p.add_argument("--corrections", help="Path to JSON/YAML corrections file")
+    p.add_argument("--resume", choices=["auto", "off"], default="auto", help="Resume from previous runs")
+    p.add_argument("--force", action="store_true", help="Force recomputation, ignore manifests")
+    p.add_argument("--resume-clean", type=int, metavar="DAYS", help="Remove manifests older than DAYS")
     args = p.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
 
     clean_intermediates = args.clean_intermediates
 
     input_path = Path(args.input)
     output_root = Path(args.output_root).resolve() if args.output_root else None
     corrections_path = Path(args.corrections).resolve() if args.corrections else None
+
+    cleaned_roots: Set[Path] = set()
 
     if input_path.is_file():
         try:
@@ -168,6 +285,10 @@ def main() -> int:
                 max_duration=args.max_duration,
                 min_gap=args.min_gap,
                 corrections_path=corrections_path,
+                resume=args.resume,
+                force=args.force,
+                resume_clean_days=args.resume_clean,
+                cleaned_roots=cleaned_roots,
             )
         except Exception:
             print(traceback.format_exc(), file=sys.stderr)
@@ -191,6 +312,10 @@ def main() -> int:
                         max_duration=args.max_duration,
                         min_gap=args.min_gap,
                         corrections_path=corrections_path,
+                        resume=args.resume,
+                        force=args.force,
+                        resume_clean_days=args.resume_clean,
+                        cleaned_roots=cleaned_roots,
                     )
                     if code != 0:
                         rc = code


### PR DESCRIPTION
## Summary
- import run-state helpers and logging into subwhisper CLI
- add resume/force options and cache-root housekeeping
- reuse stage results with manifest locks and parameter hashes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pytest tests/test_subwhisper_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d064f9c083339cd5f14c2678a937