### PR TITLE
docs: explain resume and force options

### DIFF
--- a/Getting_Started_Guide.md
+++ b/Getting_Started_Guide.md
@@ -71,7 +71,44 @@ python subwhisper_cli.py --input /path/to/your_video.mp4 --write-transcript --de
 
 This creates `your_video.txt` alongside the `.srt`.
 
-## 6) Quick tips
+## 6) Resume or recompute later
+
+Subwhisper caches progress in `.subwhisper_cache/` so you can skip completed
+work or clean up old runs.
+
+- `--resume {auto,off}` controls whether cached results are reused (`auto`
+  by default).
+- `--force` recomputes everything, ignoring any cache.
+- `--resume-clean DAYS` deletes cache manifests older than `DAYS` days before
+  starting.
+
+Examples:
+
+First run
+
+```bash
+python subwhisper_cli.py --input "…/Season 9" --device cuda
+```
+
+Resume later
+
+```bash
+python subwhisper_cli.py --input "…/Season 9" --resume auto --device cuda
+```
+
+Recompute everything
+
+```bash
+python subwhisper_cli.py --input "…/Season 9" --force
+```
+
+Clean manifests older than 14 days
+
+```bash
+python subwhisper_cli.py --input "…/Season 9" --resume-clean 14
+```
+
+## 7) Quick tips
 
 - If your computer has a supported NVIDIA GPU, try `--device cuda` for speed.
 - Cleaner audio → better subtitles. If possible, use the English audio track and reduce loud background music.
@@ -90,6 +127,10 @@ This creates `your_video.txt` alongside the `.srt`.
 - `--output-root <folder>` – put final files somewhere else
 - `--write-transcript` – also write a .txt transcript
 - `--skip-music` – ignore detected music segments
+- `--resume {auto,off}` – reuse cached results (`auto`, default) or disable
+  resuming
+- `--force` – recompute even if cached outputs exist
+- `--resume-clean DAYS` – remove manifests older than `DAYS` days
 
 ### Do it step by step
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,43 @@ subwhisper-cli --input /path/to/video.mkv --device cuda
 - Intermediates remain if the pipeline fails.
 - Use `--output-root` to redirect output or pass `--input /path/to/folder` to process an entire folder.
 
+### Resuming and recomputing
+
+The CLI keeps manifests in `.subwhisper_cache/` to skip work on subsequent
+runs. These options control how manifests are used:
+
+- `--resume {auto,off}` – reuse previous results (`auto`, default) or disable
+  resuming (`off`).
+- `--force` – recompute every stage even if manifests exist.
+- `--resume-clean DAYS` – delete manifests older than `DAYS` days before
+  starting.
+
+Examples:
+
+First run
+
+```bash
+python subwhisper_cli.py --input "…/Season 9" --device cuda
+```
+
+Resume later
+
+```bash
+python subwhisper_cli.py --input "…/Season 9" --resume auto --device cuda
+```
+
+Recompute everything
+
+```bash
+python subwhisper_cli.py --input "…/Season 9" --force
+```
+
+Clean manifests older than 14 days
+
+```bash
+python subwhisper_cli.py --input "…/Season 9" --resume-clean 14
+```
+
 ## API Authentication
 
 The accompanying FastAPI server secures its endpoints with simple


### PR DESCRIPTION
## Summary
- document `--resume`, `--force`, and `--resume-clean` flags
- add example commands for first run, resuming, recomputing, and cleaning manifests

## Testing
- `pytest tests/test_api.py tests/test_api_review.py tests/test_corrections.py tests/test_enforce_limits.py` *(partial: 8 passed, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_6898db2a044083339fbf85f31b154bce