### PR TITLE
Use Pyannote v2 VAD and warn on version mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ apply changes.
 ## Installation Prerequisites
 
 The scripts rely on a few external tools and Python packages. They have been
-tested with `whisperx>=3.4.2`, `torch==1.13.1`, and `pyannote.audio==2.1.1`.
+tested with `whisperx>=3.4.2`, `torch==1.13.1`, and `pyannote.audio>=2.1`.
 If your environment is missing these minimum versions, the CLI utilities will
 report the issue on startup. WhisperX 3.4.x does not support the `vad_filter`
 argument; to apply VAD you must either upgrade to a release that implements it
@@ -118,9 +118,10 @@ or run VAD separately with `whisperx.load_vad_model` /
 
 ### Version compatibility
 
-Pretrained Pyannote VAD models are sensitive to dependency versions. Use the
-exact pins from `requirements.txt` (or `environment.yml`) to avoid runtime
-warnings or failures:
+Pretrained Pyannote VAD models are sensitive to dependency versions. This
+project uses the `pyannote/voice-activity-detection` pipeline which requires
+`pyannote.audio` 2.x. Use the pins from `requirements.txt` (or
+`environment.yml`) to avoid runtime warnings or failures:
 
 ```bash
 pip install -r requirements.txt
@@ -128,15 +129,16 @@ pip install -r requirements.txt
 conda env create -f environment.yml
 ```
 
-These files ensure that `torch==1.13.1` and `pyannote.audio==2.1.1` are
-installed.
+These files ensure that `torch==1.13.1` and `pyannote.audio>=2.1,<3` are
+installed. The CLI performs a startup check and warns when incompatible
+versions are detected.
 
 ### Required Software
 
 - **Python**: 3.9 or newer
 - **Conda**: for managing the environment
 - **FFmpeg**: used for audio extraction
-- **Python packages**: `torch==1.13.1`, `pyannote.audio==2.1.1`, `speechbrain>=1.0`, `whisperx>=3.4.2,<4`, `librosa>=0.10`, `noisereduce>=3.0`
+- **Python packages**: `torch==1.13.1`, `pyannote.audio>=2.1,<3`, `speechbrain>=1.0`, `whisperx>=3.4.2,<4`, `librosa>=0.10`, `noisereduce>=3.0`
 
 ### Create a Conda Environment
 
@@ -147,13 +149,13 @@ conda env create -f environment.yml
 conda activate subwhisper
 ```
 
-This installs Python, `torch==1.13.1`, `pyannote.audio==2.1.1`,
+This installs Python, `torch==1.13.1`, `pyannote.audio>=2.1,<3`,
 `speechbrain>=1.0`, `whisperx>=3.4.2,<4`, and other dependencies. The `torch`
 entry is CPU‑only by default; edit `environment.yml` to choose a CUDA‑enabled
 build or add optional packages.
 
-> **Note:** The pretrained Pyannote diarization model currently requires
-> `torch==1.13.1` and `pyannote.audio==2.1.1`. Using mismatched versions may
+> **Note:** The `pyannote/voice-activity-detection` pipeline requires
+> `torch==1.13.1` and `pyannote.audio>=2.1,<3`. Using mismatched versions may
 > trigger runtime warnings or failures, so ensure your environment matches
 > these versions when relying on the pretrained model.
 
@@ -172,7 +174,7 @@ conda create -n subwhisper python=3.10
 conda activate subwhisper
 
 # Install dependencies
- pip install "torch==1.13.1" "pyannote.audio==2.1.1" "speechbrain>=1.0" "whisperx>=3.4.2,<4"
+ pip install "torch==1.13.1" "pyannote.audio>=2.1,<3" "speechbrain>=1.0" "whisperx>=3.4.2,<4"
 # Install ffmpeg (choose one of the following)
 conda install -c conda-forge ffmpeg    # via conda
 # or

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - pip:
       - ctranslate2>=4.3  # use version without pkg_resources
       - torch==1.13.1  # required for pretrained Pyannote models
-      - pyannote.audio==2.1.1  # required for pretrained Pyannote models
+      - pyannote.audio>=2.1,<3  # required for 'pyannote/voice-activity-detection'
       - speechbrain>=1.0
       - whisperx>=3.4.2,<4
       - librosa>=0.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ ctranslate2>=4.3
 # pin torch and pyannote.audio to versions compatible with the pretrained
 # Pyannote VAD model; mismatched versions can raise runtime warnings or fail
 torch==1.13.1  # required for pretrained Pyannote VAD models
-pyannote.audio==2.1.1  # required for pretrained Pyannote VAD models
+pyannote.audio>=2.1,<3  # required for 'pyannote/voice-activity-detection'
 pysubs2>=1.8.0
 speechbrain>=1.0
 whisperx>=3.4.2,<4  # use latest WhisperX

--- a/subwhisper_cli.py
+++ b/subwhisper_cli.py
@@ -21,6 +21,7 @@ from run_state import (
     CACHE_DIR,
     MANIFEST_SUFFIX,
 )
+from vad import warn_if_incompatible_pyannote
 
 logger = logging.getLogger(__name__)
 
@@ -237,6 +238,7 @@ def _process_one(
 
 
 def main() -> int:
+    warn_if_incompatible_pyannote()
     p = argparse.ArgumentParser(description="subwhisper - single command pipeline")
     p.add_argument("--input", required=True, help="Input media file or directory")
     p.add_argument("--output-root", help="Root directory for outputs (default: same as input file parent for single-file; for folder, mirrors per file parent)")

--- a/transcribe.py
+++ b/transcribe.py
@@ -59,6 +59,8 @@ import torch
 import whisperx
 import pysubs2
 
+from vad import warn_if_incompatible_pyannote
+
 from subtitle_pipeline import spellcheck_lines
 
 
@@ -130,6 +132,8 @@ def transcribe_and_align(
     dict
         Mapping containing ``transcript_json`` and ``segments_json`` paths.
     """
+    warn_if_incompatible_pyannote()
+
     if resume_outputs and all(
         resume_outputs.get(k) and os.path.exists(resume_outputs[k])
         for k in ("transcript_json", "segments_json")

--- a/vad.py
+++ b/vad.py
@@ -1,0 +1,54 @@
+"""Utilities for loading and validating Pyannote VAD models."""
+
+from __future__ import annotations
+
+import logging
+from packaging import version
+
+VAD_MODEL = "pyannote/voice-activity-detection"
+
+logger = logging.getLogger(__name__)
+
+
+def warn_if_incompatible_pyannote() -> None:
+    """Warn when installed pyannote.audio is incompatible with ``VAD_MODEL``.
+
+    The ``pyannote/voice-activity-detection`` pipeline requires
+    ``pyannote.audio`` 2.x. Older releases (0.x/1.x) are incompatible and will
+    likely fail at runtime. This check emits a warning when such a mismatch is
+    detected but does not raise an exception so the caller can decide how to
+    proceed.
+    """
+
+    try:
+        import pyannote.audio  # type: ignore
+    except Exception as exc:  # pragma: no cover - depends on environment
+        logger.warning("pyannote.audio not available: %s", exc)
+        return
+
+    installed = version.parse(pyannote.audio.__version__)
+    if installed.major < 2:  # pragma: no cover - simple branch
+        logger.warning(
+            "pyannote.audio %s detected; upgrade to >=2.0 for %s",
+            pyannote.audio.__version__,
+            VAD_MODEL,
+        )
+
+
+def load_vad_model(device: str | None = None):
+    """Load the pretrained Pyannote VAD pipeline.
+
+    Parameters
+    ----------
+    device:
+        Optional device string (e.g., ``"cpu"`` or ``"cuda"``) to move the
+        pipeline to after loading.
+    """
+    from pyannote.audio import Pipeline  # imported lazily
+
+    logger.info("Loading VAD pipeline: %s", VAD_MODEL)
+    pipeline = Pipeline.from_pretrained(VAD_MODEL)
+    if device:
+        pipeline.to(device)
+    return pipeline
+


### PR DESCRIPTION
## Summary
- pin Pyannote Audio to a 2.x-compatible range and document the required `pyannote/voice-activity-detection` pairing
- add `vad.py` helper to load the VAD pipeline and warn when an older Pyannote version is installed
- invoke the compatibility check on CLI startup

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pysubs2')*

------
https://chatgpt.com/codex/tasks/task_e_689997eae1248333b465edff97ebf38e