### PR TITLE
Ensure torchaudio uses soundfile backend on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ versions are detected.
 - **FFmpeg**: used for audio extraction
 - **Python packages**: `torch==1.13.1`, `pyannote.audio>=2.1,<3`, `speechbrain>=1.0`, `whisperx>=3.4.2,<4`, `librosa>=0.10`, `noisereduce>=3.0`
 
+On Windows, `torchaudio` must use the `soundfile` backend. Subwhisper
+configures this automatically during startup, but ensure the `soundfile`
+package and its native dependencies are installed to avoid import errors.
+
 ### Create a Conda Environment
 
 Use the provided `environment.yml` to set up everything in one step:

--- a/audio_backend.py
+++ b/audio_backend.py
@@ -1,0 +1,38 @@
+"""Helpers for configuring audio backends.
+
+This module currently ensures that torchaudio uses the ``soundfile`` backend
+on Windows.  The selection is deferred to a helper so that startup scripts can
+call it before importing libraries like :mod:`speechbrain` which inspect the
+backend at import time.
+"""
+
+from __future__ import annotations
+
+import logging
+import platform
+
+logger = logging.getLogger(__name__)
+
+
+def setup_torchaudio_backend() -> None:
+    """Configure torchaudio to use the ``soundfile`` backend on Windows.
+
+    The function is intentionally silent and best-effort: if torchaudio is
+    unavailable or the backend cannot be set, the failure is logged at debug
+    level and the program continues with torchaudio's default behaviour.
+    """
+
+    if platform.system() != "Windows":
+        return
+
+    try:  # pragma: no cover - depends on environment
+        import torchaudio  # type: ignore
+    except Exception as exc:  # pragma: no cover - torchaudio missing
+        logger.debug("torchaudio not available: %s", exc)
+        return
+
+    try:  # pragma: no cover - backend may be unavailable
+        torchaudio.set_audio_backend("soundfile")
+    except Exception as exc:  # pragma: no cover - backend may fail
+        logger.debug("failed to set torchaudio backend: %s", exc)
+

--- a/preproc.py
+++ b/preproc.py
@@ -5,6 +5,10 @@ import subprocess
 from typing import List, Optional, Tuple
 import shutil
 
+from audio_backend import setup_torchaudio_backend
+
+setup_torchaudio_backend()
+
 import librosa
 import noisereduce as nr
 import soundfile as sf

--- a/subwhisper_cli.py
+++ b/subwhisper_cli.py
@@ -6,6 +6,10 @@ import logging
 from pathlib import Path
 from typing import Optional, Tuple, Set
 
+from audio_backend import setup_torchaudio_backend
+
+setup_torchaudio_backend()
+
 from preproc import preprocess_pipeline
 from transcribe import transcribe_and_align
 from subtitle_pipeline import load_segments, enforce_limits, write_outputs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import sys
+import types
+import pytest
+
+
+_stub = types.SimpleNamespace(set_audio_backend=lambda *a, **k: None)
+sys.modules.setdefault("torchaudio", _stub)
+
+
+@pytest.fixture(autouse=True)
+def _mock_torchaudio(monkeypatch):
+    """Provide a dummy torchaudio module for tests.
+
+    The real torchaudio backend selection can emit warnings during import on
+    systems without the optional dependencies installed.  Tests stub out the
+    module to keep the output clean and deterministic.
+    """
+
+    monkeypatch.setitem(sys.modules, "torchaudio", _stub)

--- a/tests/test_audio_backend.py
+++ b/tests/test_audio_backend.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock
+import platform
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from audio_backend import setup_torchaudio_backend
+
+
+def test_setup_backend_windows(monkeypatch):
+    mock = MagicMock()
+    stub = types.SimpleNamespace(set_audio_backend=mock)
+    monkeypatch.setitem(sys.modules, "torchaudio", stub)
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    setup_torchaudio_backend()
+    mock.assert_called_once_with("soundfile")
+
+
+def test_setup_backend_non_windows(monkeypatch):
+    mock = MagicMock()
+    stub = types.SimpleNamespace(set_audio_backend=mock)
+    monkeypatch.setitem(sys.modules, "torchaudio", stub)
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+    setup_torchaudio_backend()
+    mock.assert_not_called()

--- a/transcribe.py
+++ b/transcribe.py
@@ -55,6 +55,10 @@ import os
 import inspect
 from typing import List, Optional, Tuple
 
+from audio_backend import setup_torchaudio_backend
+
+setup_torchaudio_backend()
+
 import torch
 import whisperx
 import pysubs2


### PR DESCRIPTION
## Summary
- Add `setup_torchaudio_backend` helper that selects the `soundfile` backend on Windows
- Invoke backend setup in CLI, preprocessing, and transcription entry points
- Document expected backend for Windows users and add tests that mock backend selection

## Testing
- `pytest tests/test_audio_backend.py tests/test_subwhisper_cli.py`
- `pytest tests/test_preproc.py::test_find_english_track_selects_english_stream`


------
https://chatgpt.com/codex/tasks/task_e_68999b14d9cc83338879edd3be403ed6