### PR TITLE
chore: ensure ctranslate2 avoids pkg_resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ apply changes.
 ## Installation Prerequisites
 
 The scripts rely on a few external tools and Python packages. They have been
-tested with `whisperx>=3.4.2`, `torch==1.13.1`, and `pyannote.audio>=2.1`.
-If your environment is missing these minimum versions, the CLI utilities will
+tested with `whisperx>=3.4.2`, `torch==1.13.1`, `pyannote.audio>=2.1`, and
+`ctranslate2>=4.4` (older releases depend on `pkg_resources` and may warn with
+newer versions of `setuptools`). If your environment is missing these minimum versions, the CLI utilities will
 report the issue on startup. WhisperX 3.4.x does not support the `vad_filter`
 argument; to apply VAD you must either upgrade to a release that implements it
 or run VAD separately with `whisperx.load_vad_model` /
@@ -129,9 +130,9 @@ pip install -r requirements.txt
 conda env create -f environment.yml
 ```
 
-These files ensure that `torch==1.13.1` and `pyannote.audio>=2.1,<3` are
-installed. The CLI performs a startup check and warns when incompatible
-versions are detected.
+These files ensure that `torch==1.13.1`, `pyannote.audio>=2.1,<3`, and
+`ctranslate2>=4.4` are installed. The CLI performs a startup check and warns
+when incompatible versions are detected.
 
 ### Required Software
 

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   # Uncomment the following line to match your CUDA toolkit version
   # - pytorch-cuda=11.8  # requires NVIDIA channel
   - pip:
-      - ctranslate2>=4.3  # use version without pkg_resources
+      - ctranslate2>=4.4  # requires version without pkg_resources
       - torch==1.13.1  # required for pretrained Pyannote models
       - pyannote.audio>=2.1,<3  # required for 'pyannote/voice-activity-detection'
       - speechbrain>=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ctranslate2>=4.3
+ctranslate2>=4.4
 # pin torch and pyannote.audio to versions compatible with the pretrained
 # Pyannote VAD model; mismatched versions can raise runtime warnings or fail
 torch==1.13.1  # required for pretrained Pyannote VAD models


### PR DESCRIPTION
## Summary
- require `ctranslate2>=4.4` to avoid `pkg_resources` in newer setuptools
- document ctranslate2 requirement in installation guide

## Testing
- `pytest` *(fails: AttributeError soundfile.read; AttributeError librosa.load; TypeError NoneType in transcribe tests)*
- `python transcribe.py preproc/audio_short.wav --outdir transcript_test --model tiny --device cpu --batch-size 1 --beam-size 1` *(fails: Cannot download model due to disabled network, no pkg_resources warning observed)*

------
https://chatgpt.com/codex/tasks/task_e_6899aa2ac6c883338af4352f979e7dbd