### PR TITLE
Warn when pyannote.audio version mismatches VAD model

### DIFF
--- a/subwhisper_cli.py
+++ b/subwhisper_cli.py
@@ -244,7 +244,9 @@ def _process_one(
 
 
 def main() -> int:
-    warn_if_incompatible_pyannote()
+    _msg = warn_if_incompatible_pyannote()
+    if _msg:
+        logger.warning(_msg)
     p = argparse.ArgumentParser(description="subwhisper - single command pipeline")
     p.add_argument("--input", required=True, help="Input media file or directory")
     p.add_argument("--output-root", help="Root directory for outputs (default: same as input file parent for single-file; for folder, mirrors per file parent)")

--- a/transcribe.py
+++ b/transcribe.py
@@ -137,7 +137,9 @@ def transcribe_and_align(
     dict
         Mapping containing ``transcript_json`` and ``segments_json`` paths.
     """
-    warn_if_incompatible_pyannote()
+    _msg = warn_if_incompatible_pyannote()
+    if _msg:
+        logger.warning(_msg)
 
     if resume_outputs and all(
         resume_outputs.get(k) and os.path.exists(resume_outputs[k])

--- a/vad.py
+++ b/vad.py
@@ -4,35 +4,65 @@ from __future__ import annotations
 
 import logging
 from packaging import version
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+import urllib.request
 
 VAD_MODEL = "pyannote/voice-activity-detection"
 
 logger = logging.getLogger(__name__)
 
 
-def warn_if_incompatible_pyannote() -> None:
-    """Warn when installed pyannote.audio is incompatible with ``VAD_MODEL``.
+def warn_if_incompatible_pyannote() -> str | None:
+    """Check whether ``pyannote.audio`` matches the model expectation.
 
-    The ``pyannote/voice-activity-detection`` pipeline requires
-    ``pyannote.audio`` 2.x. Older releases (0.x/1.x) are incompatible and will
-    likely fail at runtime. This check emits a warning when such a mismatch is
-    detected but does not raise an exception so the caller can decide how to
-    proceed.
+    Attempts to read the ``requirements.txt`` for ``VAD_MODEL`` from the
+    HuggingFace Hub to determine the expected ``pyannote.audio`` version. When
+    the requirement cannot be determined (e.g. due to missing network
+    connectivity) the function falls back to a simple major version check
+    requiring ``>=2``.
+
+    Returns
+    -------
+    Optional[str]
+        Warning message when an incompatibility is detected, otherwise ``None``.
     """
 
     try:
         import pyannote.audio  # type: ignore
     except Exception as exc:  # pragma: no cover - depends on environment
-        logger.warning("pyannote.audio not available: %s", exc)
-        return
+        return f"pyannote.audio not available: {exc}"
 
     installed = version.parse(pyannote.audio.__version__)
-    if installed.major < 2:  # pragma: no cover - simple branch
-        logger.warning(
-            "pyannote.audio %s detected; upgrade to >=2.0 for %s",
-            pyannote.audio.__version__,
-            VAD_MODEL,
+
+    expected: SpecifierSet | None = None
+    try:  # pragma: no cover - network dependent
+        url = f"https://huggingface.co/{VAD_MODEL}/raw/main/requirements.txt"
+        with urllib.request.urlopen(url, timeout=5) as resp:  # type: ignore[arg-type]
+            text = resp.read().decode()
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("pyannote.audio"):
+                req = Requirement(line)
+                expected = req.specifier
+                break
+    except Exception:
+        # Unable to fetch requirement; fall back to major version check
+        pass
+
+    if expected and installed not in expected:
+        return (
+            f"{VAD_MODEL} expects pyannote.audio {expected}, "
+            f"but {pyannote.audio.__version__} is installed"
         )
+
+    if installed.major < 2:  # pragma: no cover - simple branch
+        return (
+            f"pyannote.audio {pyannote.audio.__version__} detected; "
+            f"upgrade to >=2.0 for {VAD_MODEL}"
+        )
+
+    return None
 
 
 def load_vad_model(device: str | None = None):


### PR DESCRIPTION
## Summary
- detect pyannote.audio version expected by the VAD model and warn when the installed version differs
- surface pyannote warnings from transcribe_and_align and CLI entrypoint

## Testing
- `pytest tests/test_transcribe.py -q`
- `pytest tests/test_subwhisper_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6899c03ba1fc8333a9d3c8ee0ca1cc29