### PR TITLE
Log output paths after formatting stage

### DIFF
--- a/subwhisper_cli.py
+++ b/subwhisper_cli.py
@@ -224,6 +224,10 @@ def _process_one(
                 outputs.append(str(out_txt_path))
             stage_complete(media.parent, media.stem, "format", str(media), format_params, outputs)
 
+        logger.info("SRT saved to %s", out_srt)
+        if out_txt_path:
+            logger.info("Transcript saved to %s", out_txt_path)
+
         # Mark success
         success_flag = work / "SUCCESS"
         success_flag.write_text("ok", encoding="utf-8")


### PR DESCRIPTION
## Summary
- Log the SRT output path after formatting completes
- Log the transcript path when `--write-transcript` is used

## Testing
- `pytest -q` *(fails: AttributeError: <module 'soundfile'> has no attribute 'read', etc. – 16 failed, 47 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6899f03c94c88333ba4929be0e113128