### PR TITLE
Silence torchaudio backend warnings on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,10 @@ when incompatible versions are detected.
 - **Python packages**: `torch==1.13.1`, `pyannote.audio>=2.1,<3`, `speechbrain>=1.0`, `whisperx>=3.4.2,<4`, `librosa>=0.10`, `noisereduce>=3.0`
 
 On Windows, `torchaudio` must use the `soundfile` backend. Subwhisper
-configures this automatically during startup, but ensure the `soundfile`
-package and its native dependencies are installed to avoid import errors.
+configures this automatically during startup and sets
+`TORCHAUDIO_ENABLE_SOX_IO_BACKEND=0` to silence warnings about the unused
+`sox_io` backend. Ensure the `soundfile` package and its native dependencies
+are installed to avoid import errors.
 
 ### Create a Conda Environment
 

--- a/audio_backend.py
+++ b/audio_backend.py
@@ -1,14 +1,16 @@
 """Helpers for configuring audio backends.
 
-This module currently ensures that torchaudio uses the ``soundfile`` backend
-on Windows.  The selection is deferred to a helper so that startup scripts can
-call it before importing libraries like :mod:`speechbrain` which inspect the
-backend at import time.
+This module ensures that torchaudio uses the ``soundfile`` backend on
+Windows.  It also disables ``sox_io``-related warnings by setting the
+``TORCHAUDIO_ENABLE_SOX_IO_BACKEND`` environment variable.  The selection is
+deferred to a helper so that startup scripts can call it before importing
+libraries like :mod:`speechbrain` which inspect the backend at import time.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import platform
 
 logger = logging.getLogger(__name__)
@@ -24,6 +26,11 @@ def setup_torchaudio_backend() -> None:
 
     if platform.system() != "Windows":
         return
+
+    # ``torchaudio`` warns about the ``sox_io`` backend when the C++
+    # extension is unavailable.  Setting this environment variable silences
+    # the warning and makes the behaviour deterministic for callers.
+    os.environ.setdefault("TORCHAUDIO_ENABLE_SOX_IO_BACKEND", "0")
 
     try:  # pragma: no cover - depends on environment
         import torchaudio  # type: ignore

--- a/tests/test_audio_backend.py
+++ b/tests/test_audio_backend.py
@@ -1,4 +1,6 @@
 from unittest.mock import MagicMock
+import logging
+import os
 import platform
 import sys
 import types
@@ -12,16 +14,30 @@ from audio_backend import setup_torchaudio_backend
 def test_setup_backend_windows(monkeypatch):
     mock = MagicMock()
     stub = types.SimpleNamespace(set_audio_backend=mock)
+    monkeypatch.delenv("TORCHAUDIO_ENABLE_SOX_IO_BACKEND", raising=False)
     monkeypatch.setitem(sys.modules, "torchaudio", stub)
     monkeypatch.setattr(platform, "system", lambda: "Windows")
     setup_torchaudio_backend()
     mock.assert_called_once_with("soundfile")
+    assert os.environ["TORCHAUDIO_ENABLE_SOX_IO_BACKEND"] == "0"
 
 
 def test_setup_backend_non_windows(monkeypatch):
     mock = MagicMock()
     stub = types.SimpleNamespace(set_audio_backend=mock)
+    monkeypatch.delenv("TORCHAUDIO_ENABLE_SOX_IO_BACKEND", raising=False)
     monkeypatch.setitem(sys.modules, "torchaudio", stub)
     monkeypatch.setattr(platform, "system", lambda: "Linux")
     setup_torchaudio_backend()
     mock.assert_not_called()
+    assert "TORCHAUDIO_ENABLE_SOX_IO_BACKEND" not in os.environ
+
+
+def test_setup_backend_no_warning(monkeypatch, caplog):
+    stub = types.SimpleNamespace(set_audio_backend=lambda *a, **k: None)
+    monkeypatch.delenv("TORCHAUDIO_ENABLE_SOX_IO_BACKEND", raising=False)
+    monkeypatch.setitem(sys.modules, "torchaudio", stub)
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    with caplog.at_level(logging.WARNING):
+        setup_torchaudio_backend()
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]


### PR DESCRIPTION
## Summary
- prevent redundant torchaudio warnings on Windows by setting `TORCHAUDIO_ENABLE_SOX_IO_BACKEND`
- document Windows backend configuration
- test that the backend setup emits no warnings on Windows

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pytest tests/test_audio_backend.py`

------
https://chatgpt.com/codex/tasks/task_e_689a1a8eb8e08333ade7737c9dbd5291