### PR TITLE
Upgrade dependencies to remove pkg_resources usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ apply changes.
 ## Installation Prerequisites
 
 The scripts rely on a few external tools and Python packages. They have been
-tested with `whisperx>=3.4.2`, `torch==1.13.1`, `pyannote.audio>=2.1`, and
-`ctranslate2>=4.4` (older releases depend on `pkg_resources` and may warn with
-newer versions of `setuptools`). If your environment is missing these minimum versions, the CLI utilities will
+tested with `whisperx>=3.4.2`, `torch>=2.5.1`, `pyannote.audio>=3.3.2`, and
+`ctranslate2>=4.4` (modern releases use `importlib.metadata` instead of
+`pkg_resources`). If your environment is missing these minimum versions, the CLI utilities will
 report the issue on startup. WhisperX 3.4.x does not support the `vad_filter`
 argument; to apply VAD you must either upgrade to a release that implements it
 or run VAD separately with `whisperx.load_vad_model` /
@@ -120,8 +120,8 @@ or run VAD separately with `whisperx.load_vad_model` /
 ### Version compatibility
 
 Pretrained Pyannote VAD models are sensitive to dependency versions. This
-project uses the `pyannote/voice-activity-detection` pipeline which requires
-`pyannote.audio` 2.x. Use the pins from `requirements.txt` (or
+project uses the `pyannote/voice-activity-detection` pipeline from
+`pyannote.audio` 3.x. Use the pins from `requirements.txt` (or
 `environment.yml`) to avoid runtime warnings or failures:
 
 ```bash
@@ -130,7 +130,7 @@ pip install -r requirements.txt
 conda env create -f environment.yml
 ```
 
-These files ensure that `torch==1.13.1`, `pyannote.audio>=2.1,<3`, and
+These files ensure that `torch>=2.5.1`, `pyannote.audio>=3.3.2`, and
 `ctranslate2>=4.4` are installed. The CLI performs a startup check and warns
 when incompatible versions are detected.
 
@@ -139,7 +139,7 @@ when incompatible versions are detected.
 - **Python**: 3.9 or newer
 - **Conda**: for managing the environment
 - **FFmpeg**: used for audio extraction
-- **Python packages**: `torch==1.13.1`, `pyannote.audio>=2.1,<3`, `speechbrain>=1.0`, `whisperx>=3.4.2,<4`, `librosa>=0.10`, `noisereduce>=3.0`
+- **Python packages**: `torch>=2.5.1`, `pyannote.audio>=3.3.2`, `lightning>=2.5.2`, `speechbrain>=1.0`, `whisperx>=3.4.2,<4`, `librosa>=0.10`, `noisereduce>=3.0`
 
 On Windows, `torchaudio` must use the `soundfile` backend. Subwhisper
 configures this automatically during startup and sets
@@ -156,15 +156,13 @@ conda env create -f environment.yml
 conda activate subwhisper
 ```
 
-This installs Python, `torch==1.13.1`, `pyannote.audio>=2.1,<3`,
+This installs Python, `torch>=2.5.1`, `pyannote.audio>=3.3.2`,
 `speechbrain>=1.0`, `whisperx>=3.4.2,<4`, and other dependencies. The `torch`
 entry is CPU‑only by default; edit `environment.yml` to choose a CUDA‑enabled
 build or add optional packages.
 
-> **Note:** The `pyannote/voice-activity-detection` pipeline requires
-> `torch==1.13.1` and `pyannote.audio>=2.1,<3`. Using mismatched versions may
-> trigger runtime warnings or failures, so ensure your environment matches
-> these versions when relying on the pretrained model.
+> **Note:** `pyannote.audio` 3.x depends on `lightning` and uses
+> `importlib.metadata`, avoiding legacy `pkg_resources` warnings.
 
 #### Upgrading dependencies
 
@@ -181,7 +179,7 @@ conda create -n subwhisper python=3.10
 conda activate subwhisper
 
 # Install dependencies
- pip install "torch==1.13.1" "pyannote.audio>=2.1,<3" "speechbrain>=1.0" "whisperx>=3.4.2,<4"
+ pip install "torch>=2.5.1" "pyannote.audio>=3.3.2" "lightning>=2.5.2" "speechbrain>=1.0" "whisperx>=3.4.2,<4"
 # Install ffmpeg (choose one of the following)
 conda install -c conda-forge ffmpeg    # via conda
 # or
@@ -190,11 +188,11 @@ sudo apt-get install ffmpeg            # on Debian/Ubuntu
 
 #### Upgrading PyTorch Lightning checkpoints
 
-Older models saved with previous versions of PyTorch Lightning may need to be
+Older models saved with previous versions of Lightning may need to be
 upgraded before use. If you see a warning about `pytorch_model.bin`, run:
 
 ```bash
-python -m pytorch_lightning.utilities.upgrade_checkpoint /path/to/pytorch_model.bin
+python -m lightning.pytorch.utilities.upgrade_checkpoint /path/to/pytorch_model.bin
 ```
 
 This converts the checkpoint to the latest format so it can be loaded without

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,6 @@
+# Release Notes
+
+## Unreleased
+- Upgrade dependencies to drop `pkg_resources` usage:
+  - `pyannote.audio>=3.3.2` now depends on `lightning` instead of `pytorch-lightning`.
+  - Require `torch>=2.5.1` and `lightning>=2.5.2` to align with the new stack.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 ctranslate2>=4.4
-# pin torch and pyannote.audio to versions compatible with the pretrained
-# Pyannote VAD model; mismatched versions can raise runtime warnings or fail
-torch==1.13.1  # required for pretrained Pyannote VAD models
-pyannote.audio>=2.1,<3  # required for 'pyannote/vad'
+# Updated to rely on modern releases that replace `pkg_resources` with
+# `importlib.metadata` and drop the old `pytorch-lightning` dependency.
+torch>=2.5.1  # required for Pyannote 3.x
+pyannote.audio>=3.3.2  # uses `lightning` instead of `pytorch-lightning`
+lightning>=2.5.2
 pysubs2>=1.8.0
 speechbrain>=1.0
 whisperx>=3.4.2,<4  # use latest WhisperX


### PR DESCRIPTION
## Summary
- upgrade to pyannote.audio 3.3.2 and torch 2.5+ and add lightning 2.5 to avoid `pkg_resources`
- document new dependency stack and create release notes entry

## Testing
- `pytest` *(fails: module 'torch' has no attribute 'no_grad')*

------
https://chatgpt.com/codex/tasks/task_e_689a269815cc83338ca5b830e060c112