### PR TITLE
Check pyannote version for align models

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - pip:
       - ctranslate2>=4.4  # requires version without pkg_resources
       - torch==1.13.1  # required for pretrained Pyannote models
-      - pyannote.audio>=2.1,<3  # required for 'pyannote/vad'
+      - pyannote.audio>=2.1,<3  # required for 'pyannote/vad' and align models
       - speechbrain>=1.0
       - whisperx>=3.4.2,<4
       - librosa>=0.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
 ctranslate2>=4.4
-# Updated to rely on modern releases that replace `pkg_resources` with
-# `importlib.metadata` and drop the old `pytorch-lightning` dependency.
-torch>=2.5.1  # required for Pyannote 3.x
-pyannote.audio>=3.3.2  # uses `lightning` instead of `pytorch-lightning`
-lightning>=2.5.2
+torch==1.13.1  # required for pretrained Pyannote models
+pyannote.audio>=2.1,<3  # required for 'pyannote/vad' and align models
 pysubs2>=1.8.0
 speechbrain>=1.0
 whisperx>=3.4.2,<4  # use latest WhisperX

--- a/transcribe.py
+++ b/transcribe.py
@@ -138,8 +138,8 @@ def transcribe_and_align(
         Mapping containing ``transcript_json`` and ``segments_json`` paths.
     """
     # Abort early when the installed ``pyannote.audio`` is incompatible with
-    # the expected version for the VAD model.
-    warn_if_incompatible_pyannote()
+    # the expected versions for the VAD and alignment models.
+    warn_if_incompatible_pyannote([ALIGN_MODEL_NAME])
 
     if resume_outputs and all(
         resume_outputs.get(k) and os.path.exists(resume_outputs[k])


### PR DESCRIPTION
## Summary
- ensure Pyannote audio version matches expectations for VAD and WhisperX alignment models
- pin Pyannote 2.x dependencies in requirements and environment files
- add regression test for version mismatch errors

## Testing
- `pytest tests/test_transcribe.py -q`
- `pytest tests/test_transcribe.py::test_pyannote_version_mismatch_raises -q`
- `pytest -q` *(fails: AttributeError: module 'transcribe' has no attribute 'main', FileNotFoundError: transcript.json, TypeError: 'NoneType' object is not subscriptable)*

------
https://chatgpt.com/codex/tasks/task_e_689a3cd08d288333bfcd9f6499ed73cc