### PR TITLE
Silence Speechbrain torchaudio backend warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@ when incompatible versions are detected.
 - **Python packages**: `torch>=2.5.1`, `pyannote.audio>=3.3.2`, `lightning>=2.5.2`, `speechbrain>=1.0`, `whisperx>=3.4.2,<4`, `librosa>=0.10`, `noisereduce>=3.0`
 
 On Windows, `torchaudio` must use the `soundfile` backend. Subwhisper
-configures this automatically during startup and sets
-`TORCHAUDIO_ENABLE_SOX_IO_BACKEND=0` to silence warnings about the unused
+configures this automatically during startup, suppresses
+`speechbrain.utils.torch_audio_backend` warnings, and sets
+`TORCHAUDIO_ENABLE_SOX_IO_BACKEND=0` to silence messages about the unused
 `sox_io` backend. Ensure the `soundfile` package and its native dependencies
 are installed to avoid import errors.
 

--- a/audio_backend.py
+++ b/audio_backend.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import os
 import platform
+import warnings
 
 logger = logging.getLogger(__name__)
 
@@ -42,4 +43,14 @@ def setup_torchaudio_backend() -> None:
         torchaudio.set_audio_backend("soundfile")
     except Exception as exc:  # pragma: no cover - backend may fail
         logger.debug("failed to set torchaudio backend: %s", exc)
+    else:
+        # ``speechbrain.utils.torch_audio_backend`` prints warnings about the
+        # selected backend.  Suppress them since "soundfile" is expected on
+        # Windows.
+        warnings.filterwarnings(
+            "ignore", module="speechbrain.utils.torch_audio_backend"
+        )
+        logging.getLogger(
+            "speechbrain.utils.torch_audio_backend"
+        ).setLevel(logging.ERROR)
 

--- a/tests/test_audio_backend.py
+++ b/tests/test_audio_backend.py
@@ -41,3 +41,19 @@ def test_setup_backend_no_warning(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING):
         setup_torchaudio_backend()
     assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_speechbrain_logger_suppressed(monkeypatch, caplog):
+    stub = types.SimpleNamespace(set_audio_backend=lambda *a, **k: None)
+    monkeypatch.delenv("TORCHAUDIO_ENABLE_SOX_IO_BACKEND", raising=False)
+    monkeypatch.setitem(sys.modules, "torchaudio", stub)
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+
+    logger = logging.getLogger("speechbrain.utils.torch_audio_backend")
+    logger.setLevel(logging.WARNING)
+
+    setup_torchaudio_backend()
+
+    with caplog.at_level(logging.WARNING):
+        logger.warning("boom")
+    assert not [r for r in caplog.records if r.name == "speechbrain.utils.torch_audio_backend"]


### PR DESCRIPTION
## Summary
- mute `speechbrain.utils.torch_audio_backend` warnings after forcing `soundfile` backend on Windows
- document Windows-only `soundfile` backend behavior and warning suppression
- add regression test ensuring Speechbrain warnings are filtered

## Testing
- `pytest tests/test_audio_backend.py`


------
https://chatgpt.com/codex/tasks/task_e_689a43b138508333ac0503b3a3c780d9